### PR TITLE
Add developer docs portal structure

### DIFF
--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -19,7 +19,7 @@ Color system:
 
 UI system:
 
-- Header: Realtek logo slot or text wordmark, Connect+ brand, Features, Architecture, Contact.
+- Header: Realtek logo slot or text wordmark, Connect+ brand, Docs, Features, Architecture, Contact.
 - Buttons: solid teal primary and restrained outline secondary.
 - Cards: 6-8px radius, thin border, minimal shadow.
 - Hero: direct product positioning with a platform architecture poster image.
@@ -48,6 +48,8 @@ Realtek Connect+ presents the following ESP RainMaker-aligned capabilities:
 Routes:
 
 - `GET /`: homepage.
+- `GET /docs`: developer/documentation portal landing page.
+- `GET /docs/{slug}`: developer/documentation section detail pages.
 - `GET /features`: feature overview.
 - `GET /features/{slug}`: feature detail pages.
 - `GET /contact`: contact / early access registration form.
@@ -63,6 +65,17 @@ Feature slugs:
 - `insights`
 - `private-cloud`
 - `integrations`
+
+Documentation slugs:
+
+- `product-overview`
+- `development`
+- `apis`
+- `sdks`
+- `firmware`
+- `cli`
+- `deployment`
+- `release-notes`
 
 Environment:
 

--- a/internal/docs/docs.go
+++ b/internal/docs/docs.go
@@ -1,0 +1,106 @@
+package docs
+
+type Section struct {
+	Slug         string
+	Title        string
+	Kicker       string
+	Summary      string
+	Description  string
+	Highlights   []string
+	Deliverables []string
+	Audience     []string
+}
+
+func All() []Section {
+	return []Section{
+		{
+			Slug:         "product-overview",
+			Title:        "Product Overview",
+			Kicker:       "Position the platform before diving into implementation.",
+			Summary:      "Platform architecture, capability map, and commercial packaging guidance for Realtek Connect+ evaluations.",
+			Description:  "Product Overview is the landing space for teams comparing platform scope, architecture boundaries, and rollout priorities. It frames how device firmware, cloud services, apps, operations, and enterprise deployment fit together without implying the website itself runs those systems.",
+			Highlights:   []string{"Platform architecture narrative", "Capability map across onboarding, OTA, app, insights, and cloud", "Commercial evaluation framing for product teams"},
+			Deliverables: []string{"Architecture diagrams and lifecycle summaries", "Capability comparison tables for internal alignment", "Evaluation guidance for hardware, mobile, and cloud stakeholders"},
+			Audience:     []string{"Product managers evaluating commercial fit", "Solution architects mapping Realtek platform scope", "Sales engineers preparing technical discovery"},
+		},
+		{
+			Slug:         "development",
+			Title:        "Development",
+			Kicker:       "Organize firmware, cloud, and app workstreams around one delivery plan.",
+			Summary:      "Environment setup, team responsibilities, and implementation tracks for device, cloud, mobile, and operations teams.",
+			Description:  "Development outlines how engineering teams move from proof-of-concept into execution. It explains the expected workstreams, the handoffs between firmware and cloud teams, and the checkpoints needed before release and deployment readiness reviews.",
+			Highlights:   []string{"Suggested phase plan from prototype to production", "Shared responsibilities across firmware, mobile, cloud, and QA", "Integration checkpoints for provisioning, OTA, and operations"},
+			Deliverables: []string{"Environment bootstrap checklists", "Cross-team implementation milestones", "Validation gates before field pilots"},
+			Audience:     []string{"Engineering managers planning delivery", "Firmware and app leads coordinating dependencies", "QA teams defining release readiness"},
+		},
+		{
+			Slug:         "apis",
+			Title:        "APIs",
+			Kicker:       "Expose cloud capabilities through structured integration surfaces.",
+			Summary:      "REST, MQTT over TLS, webhook, and service contract documentation entry points for external systems.",
+			Description:  "APIs describes the contract layer around Realtek Connect+. It positions cloud APIs as the integration surface for dashboards, support tooling, business systems, and device event workflows, while keeping the first implementation static and server-rendered.",
+			Highlights:   []string{"REST resource categories for devices, users, OTA, and analytics", "MQTT over TLS for device messaging and state updates", "Webhook patterns for operational event delivery"},
+			Deliverables: []string{"Authentication and authorization model overview", "Endpoint families and payload expectations", "Integration examples for support and CRM workflows"},
+			Audience:     []string{"Backend teams integrating cloud services", "Partner engineers building business system hooks", "Technical account teams answering API scope questions"},
+		},
+		{
+			Slug:         "sdks",
+			Title:        "SDKs",
+			Kicker:       "Document the developer surfaces used to build connected product experiences.",
+			Summary:      "Mobile SDK, firmware SDK, and reusable client components for branded product delivery.",
+			Description:  "SDKs serves as the catalog of implementation building blocks. It connects mobile, firmware, and service-side integration stories so product teams can understand which surfaces are reused, customized, or wrapped for their own connected product launch.",
+			Highlights:   []string{"iOS and Android mobile integration path", "Firmware-side service and identity building blocks", "Sample client components for branded product apps"},
+			Deliverables: []string{"SDK selection guidance by product type", "Customization boundaries for branded experiences", "Support expectations for onboarding and lifecycle features"},
+			Audience:     []string{"Mobile engineers integrating branded apps", "Embedded developers mapping device-side dependencies", "Program leads planning reuse vs customization"},
+		},
+		{
+			Slug:         "firmware",
+			Title:        "Firmware",
+			Kicker:       "Clarify what the device software stack must provide.",
+			Summary:      "Provisioning, identity, telemetry, OTA agent, and diagnostics expectations for device firmware teams.",
+			Description:  "Firmware documents the device-side responsibilities required to make cloud features credible. It maps the expected lifecycle hooks for onboarding, signal reporting, OTA safety, and device health so teams can scope implementation effort before integration begins.",
+			Highlights:   []string{"Provisioning and claim flow responsibilities", "OTA validation, targeting, and rollback safety concepts", "Health signal and diagnostics reporting expectations"},
+			Deliverables: []string{"Firmware capability checklist", "Integration points for cloud identity and telemetry", "Release-readiness topics for factory and field updates"},
+			Audience:     []string{"Embedded teams implementing device services", "System architects aligning firmware and cloud contracts", "Operations teams reviewing field support hooks"},
+		},
+		{
+			Slug:         "cli",
+			Title:        "CLI",
+			Kicker:       "Support operators and developers with repeatable command-line workflows.",
+			Summary:      "Command-line entry points for local testing, release preparation, fleet actions, and support diagnostics.",
+			Description:  "CLI frames the operational workflows that often accompany a commercial IoT platform. It covers the kinds of scripted tasks operators and developers expect, from local environment setup to release packaging, diagnostics collection, and bulk maintenance actions.",
+			Highlights:   []string{"Local developer setup and smoke commands", "Bulk operational workflows for support teams", "Release and environment maintenance scripts"},
+			Deliverables: []string{"Command catalog for setup, test, release, and support", "Operator guardrails for high-impact actions", "Examples for scripted environment workflows"},
+			Audience:     []string{"Developers running local test flows", "Support engineers handling fleet maintenance", "DevOps teams standardizing release automation"},
+		},
+		{
+			Slug:         "deployment",
+			Title:        "Deployment",
+			Kicker:       "Show how evaluation environments mature into commercial cloud footprints.",
+			Summary:      "Public evaluation, private deployment, regional topology, reverse proxy TLS, and operations ownership guidance.",
+			Description:  "Deployment explains how teams move from a public evaluation story into controlled commercial environments. It distinguishes website content from real cloud operations, and it outlines the packaging, ownership, and infrastructure concerns needed for customer-specific rollout planning.",
+			Highlights:   []string{"Public evaluation versus private commercial deployment", "Regional hosting and custom domain considerations", "TLS and ingress handled by deployment environment or reverse proxy"},
+			Deliverables: []string{"Deployment topology comparison", "Infrastructure ownership matrix", "Operational readiness FAQ for enterprise customers"},
+			Audience:     []string{"Platform teams planning hosted environments", "Enterprise buyers evaluating data boundaries", "DevOps engineers preparing deployment standards"},
+		},
+		{
+			Slug:         "release-notes",
+			Title:        "Release Notes",
+			Kicker:       "Track product evolution across firmware, cloud, app, and ops surfaces.",
+			Summary:      "Versioned change logs, upgrade notes, compatibility statements, and rollout communication patterns.",
+			Description:  "Release Notes defines the documentation structure teams expect once the platform is shipping updates regularly. It sets up a home for product version changes, upgrade implications, and compatibility notes across firmware, cloud, mobile app, and operational tooling.",
+			Highlights:   []string{"Version-by-version product change summaries", "Upgrade notes and compatibility callouts", "Customer-facing communication structure for releases"},
+			Deliverables: []string{"Release note template for cloud, app, and firmware updates", "Upgrade impact sections by audience", "Archive strategy for historical product changes"},
+			Audience:     []string{"Customer success teams preparing release comms", "Engineering teams documenting compatibility changes", "Product leadership tracking roadmap delivery"},
+		},
+	}
+}
+
+func BySlug(slug string) (Section, bool) {
+	for _, section := range All() {
+		if section.Slug == slug {
+			return section, true
+		}
+	}
+	return Section{}, false
+}

--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"time"
 
+	"realtek-connect/internal/docs"
 	"realtek-connect/internal/features"
 	"realtek-connect/internal/leads"
 )
@@ -32,6 +33,8 @@ type Server struct {
 type pageData struct {
 	Title        string
 	CurrentPath  string
+	Docs         []docs.Section
+	Doc          docs.Section
 	Features     []features.Feature
 	Feature      features.Feature
 	Form         contactForm
@@ -66,6 +69,8 @@ func (s *Server) Routes() http.Handler {
 	mux := http.NewServeMux()
 	mux.Handle("/static/", http.StripPrefix("/static/", http.FileServer(http.Dir(s.staticDir))))
 	mux.HandleFunc("/", s.handleHome)
+	mux.HandleFunc("/docs", s.handleDocs)
+	mux.HandleFunc("/docs/", s.handleDocDetail)
 	mux.HandleFunc("/features", s.handleFeatures)
 	mux.HandleFunc("/features/", s.handleFeatureDetail)
 	mux.HandleFunc("/contact", s.handleContact)
@@ -84,6 +89,52 @@ func (s *Server) handleHome(w http.ResponseWriter, r *http.Request) {
 	s.render(w, http.StatusOK, "home.html", pageData{
 		Title:       "Realtek Connect+ | IoT Cloud Platform",
 		CurrentPath: r.URL.Path,
+		Docs:        docs.All(),
+		Features:    features.All(),
+	})
+}
+
+func (s *Server) handleDocs(w http.ResponseWriter, r *http.Request) {
+	if r.URL.Path != "/docs" {
+		http.NotFound(w, r)
+		return
+	}
+	if r.Method != http.MethodGet {
+		methodNotAllowed(w)
+		return
+	}
+	s.render(w, http.StatusOK, "docs.html", pageData{
+		Title:       "Developer Docs | Realtek Connect+",
+		CurrentPath: r.URL.Path,
+		Docs:        docs.All(),
+		Features:    features.All(),
+	})
+}
+
+func (s *Server) handleDocDetail(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		methodNotAllowed(w)
+		return
+	}
+
+	slug := strings.TrimPrefix(r.URL.Path, "/docs/")
+	slug = strings.Trim(slug, "/")
+	if slug == "" {
+		http.Redirect(w, r, "/docs", http.StatusSeeOther)
+		return
+	}
+
+	doc, ok := docs.BySlug(slug)
+	if !ok {
+		http.NotFound(w, r)
+		return
+	}
+
+	s.render(w, http.StatusOK, "doc.html", pageData{
+		Title:       doc.Title + " | Realtek Connect+ Docs",
+		CurrentPath: r.URL.Path,
+		Docs:        docs.All(),
+		Doc:         doc,
 		Features:    features.All(),
 	})
 }
@@ -100,6 +151,7 @@ func (s *Server) handleFeatures(w http.ResponseWriter, r *http.Request) {
 	s.render(w, http.StatusOK, "features.html", pageData{
 		Title:       "Features | Realtek Connect+",
 		CurrentPath: r.URL.Path,
+		Docs:        docs.All(),
 		Features:    features.All(),
 	})
 }
@@ -126,6 +178,7 @@ func (s *Server) handleFeatureDetail(w http.ResponseWriter, r *http.Request) {
 	s.render(w, http.StatusOK, "feature.html", pageData{
 		Title:       feature.Title + " | Realtek Connect+",
 		CurrentPath: r.URL.Path,
+		Docs:        docs.All(),
 		Feature:     feature,
 		Features:    features.All(),
 	})
@@ -137,6 +190,7 @@ func (s *Server) handleContact(w http.ResponseWriter, r *http.Request) {
 		s.render(w, http.StatusOK, "contact.html", pageData{
 			Title:       "Contact | Realtek Connect+",
 			CurrentPath: r.URL.Path,
+			Docs:        docs.All(),
 			Features:    features.All(),
 		})
 	case http.MethodPost:
@@ -165,6 +219,7 @@ func (s *Server) submitContact(w http.ResponseWriter, r *http.Request) {
 		s.render(w, http.StatusBadRequest, "contact.html", pageData{
 			Title:       "Contact | Realtek Connect+",
 			CurrentPath: r.URL.Path,
+			Docs:        docs.All(),
 			Features:    features.All(),
 			Form:        form,
 			Errors:      errors,
@@ -191,6 +246,7 @@ func (s *Server) submitContact(w http.ResponseWriter, r *http.Request) {
 	s.render(w, http.StatusOK, "contact.html", pageData{
 		Title:        "Contact | Realtek Connect+",
 		CurrentPath:  r.URL.Path,
+		Docs:         docs.All(),
 		Features:     features.All(),
 		Success:      true,
 		SubmittedFor: form.Name,

--- a/internal/web/server_test.go
+++ b/internal/web/server_test.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"testing"
 
+	"realtek-connect/internal/docs"
 	"realtek-connect/internal/features"
 	"realtek-connect/internal/leads"
 )
@@ -36,7 +37,10 @@ func testServer(t *testing.T, store LeadStore) http.Handler {
 
 func TestRoutesReturnOK(t *testing.T) {
 	handler := testServer(t, &memoryLeadStore{})
-	paths := []string{"/", "/features", "/contact"}
+	paths := []string{"/", "/docs", "/features", "/contact"}
+	for _, section := range docs.All() {
+		paths = append(paths, "/docs/"+section.Slug)
+	}
 	for _, feature := range features.All() {
 		paths = append(paths, "/features/"+feature.Slug)
 	}
@@ -55,6 +59,18 @@ func TestUnknownFeatureReturnsNotFound(t *testing.T) {
 	handler := testServer(t, &memoryLeadStore{})
 
 	req := httptest.NewRequest(http.MethodGet, "/features/unknown", nil)
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("status = %d, want 404", rec.Code)
+	}
+}
+
+func TestUnknownDocReturnsNotFound(t *testing.T) {
+	handler := testServer(t, &memoryLeadStore{})
+
+	req := httptest.NewRequest(http.MethodGet, "/docs/unknown", nil)
 	rec := httptest.NewRecorder()
 	handler.ServeHTTP(rec, req)
 

--- a/static/styles.css
+++ b/static/styles.css
@@ -303,6 +303,10 @@ p {
   color: var(--muted);
 }
 
+.feature-card li + li {
+  margin-top: 8px;
+}
+
 .text-link {
   margin-top: auto;
   font-weight: 780;
@@ -445,6 +449,34 @@ p {
   background: var(--bg-panel);
 }
 
+.docs-entry-grid {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 18px;
+  margin-top: 30px;
+}
+
+.docs-card {
+  min-height: 0;
+}
+
+.docs-card h2,
+.docs-card h3 {
+  margin-top: 8px;
+}
+
+.docs-card p {
+  margin-bottom: 18px;
+}
+
+.docs-hero {
+  max-width: 920px;
+}
+
+.docs-structure {
+  border-top: 1px solid var(--line);
+}
+
 form {
   display: grid;
   gap: 16px;
@@ -525,6 +557,7 @@ textarea:focus {
   }
 
   .feature-grid,
+  .docs-entry-grid,
   .use-case-list,
   .detail-grid {
     grid-template-columns: repeat(2, minmax(0, 1fr));
@@ -571,6 +604,7 @@ textarea:focus {
   }
 
   .feature-grid,
+  .docs-entry-grid,
   .use-case-list,
   .detail-grid {
     grid-template-columns: 1fr;

--- a/templates/doc.html
+++ b/templates/doc.html
@@ -1,0 +1,57 @@
+{{define "content"}}
+<section class="page-hero feature-detail">
+  <p class="eyebrow">{{.Doc.Kicker}}</p>
+  <h1>{{.Doc.Title}}</h1>
+  <p>{{.Doc.Description}}</p>
+  <div class="hero-actions">
+    <a class="button primary" href="/docs">Back to docs</a>
+    <a class="button secondary" href="/contact">Discuss implementation</a>
+  </div>
+</section>
+
+<section class="section detail-grid">
+  <article class="detail-panel">
+    <p class="eyebrow">Coverage</p>
+    <h2>What this section explains</h2>
+    <ul class="check-list">
+      {{range .Doc.Highlights}}
+      <li>{{.}}</li>
+      {{end}}
+    </ul>
+  </article>
+  <article class="detail-panel">
+    <p class="eyebrow">Expected outputs</p>
+    <h2>What teams should be able to leave with</h2>
+    <ul class="check-list">
+      {{range .Doc.Deliverables}}
+      <li>{{.}}</li>
+      {{end}}
+    </ul>
+  </article>
+  <article class="detail-panel accent-panel">
+    <p class="eyebrow">Primary audience</p>
+    <h2>Who should start here</h2>
+    <ul class="check-list">
+      {{range .Doc.Audience}}
+      <li>{{.}}</li>
+      {{end}}
+    </ul>
+  </article>
+</section>
+
+<section class="section doc-navigation">
+  <div class="section-heading">
+    <p class="eyebrow">Next sections</p>
+    <h2>Continue through the developer portal.</h2>
+  </div>
+  <div class="docs-entry-grid">
+    {{range .Docs}}
+    <a class="feature-card docs-card" href="/docs/{{.Slug}}">
+      <h3>{{.Title}}</h3>
+      <p>{{.Summary}}</p>
+      <span class="text-link">View section</span>
+    </a>
+    {{end}}
+  </div>
+</section>
+{{end}}

--- a/templates/docs.html
+++ b/templates/docs.html
@@ -1,0 +1,54 @@
+{{define "content"}}
+<section class="page-hero docs-hero">
+  <p class="eyebrow">Developer docs</p>
+  <h1>Documentation entry points for cloud, firmware, app, and deployment teams.</h1>
+  <p>Realtek Connect+ now includes a server-rendered documentation portal structure covering platform overview, development, APIs, SDKs, firmware, CLI workflows, deployment, and release notes.</p>
+  <div class="hero-actions">
+    <a class="button primary" href="/contact">Talk to the platform team</a>
+    <a class="button secondary" href="/features/app-sdk">See app platform context</a>
+  </div>
+</section>
+
+<section class="section">
+  <div class="section-heading">
+    <p class="eyebrow">Portal structure</p>
+    <h2>Choose the track that matches your workstream.</h2>
+  </div>
+  <div class="docs-entry-grid">
+    {{range .Docs}}
+    <a class="feature-card docs-card tall" href="/docs/{{.Slug}}">
+      <p class="card-kicker">{{.Kicker}}</p>
+      <h2>{{.Title}}</h2>
+      <p>{{.Summary}}</p>
+      <ul>
+        {{range .Highlights}}
+        <li>{{.}}</li>
+        {{end}}
+      </ul>
+      <span class="text-link">Open section</span>
+    </a>
+    {{end}}
+  </div>
+</section>
+
+<section class="section docs-structure">
+  <div class="section-heading">
+    <p class="eyebrow">Why this matters</p>
+    <h2>Mirror the documentation surfaces teams expect before product launch.</h2>
+  </div>
+  <div class="use-case-list">
+    <article>
+      <h3>Shared platform narrative</h3>
+      <p>Give product, sales, and engineering stakeholders one place to understand lifecycle scope before implementation deep-dives.</p>
+    </article>
+    <article>
+      <h3>Workstream-specific depth</h3>
+      <p>Separate firmware, API, mobile SDK, deployment, and release concerns so each team can navigate directly to its implementation surface.</p>
+    </article>
+    <article>
+      <h3>Static first version</h3>
+      <p>Keep the docs portal compatible with the current Go templates and server-rendered architecture while leaving space for deeper follow-on content.</p>
+    </article>
+  </div>
+</section>
+{{end}}

--- a/templates/home.html
+++ b/templates/home.html
@@ -92,6 +92,23 @@
   </div>
 </section>
 
+<section class="section docs-entry" id="docs">
+  <div class="section-heading">
+    <p class="eyebrow">Developer portal</p>
+    <h2>Give product, firmware, app, and cloud teams one documentation spine.</h2>
+  </div>
+  <div class="docs-entry-grid">
+    {{range .Docs}}
+    <a class="feature-card docs-card" href="/docs/{{.Slug}}">
+      <p class="card-kicker">{{.Kicker}}</p>
+      <h3>{{.Title}}</h3>
+      <p>{{.Summary}}</p>
+      <span class="text-link">Open section</span>
+    </a>
+    {{end}}
+  </div>
+</section>
+
 <section class="cta-band" id="contact">
   <div>
     <p class="eyebrow">Early access</p>

--- a/templates/layout.html
+++ b/templates/layout.html
@@ -16,6 +16,7 @@
       <span class="brand-product">Connect+</span>
     </a>
     <nav class="main-nav" aria-label="Main navigation">
+      <a href="/docs">Docs</a>
       <a href="/features">Features</a>
       <a href="/#architecture">Architecture</a>
       <a href="/contact" class="nav-cta">Contact</a>
@@ -32,6 +33,7 @@
       <p>IoT cloud platform concept for Realtek-based connected products.</p>
     </div>
     <div class="footer-links">
+      <a href="/docs">Developer Docs</a>
       <a href="/features">Features</a>
       <a href="/contact">Contact Sales</a>
     </div>


### PR DESCRIPTION
## Summary
- add a server-rendered developer docs portal with landing and detail routes
- expose Docs in the main navigation and add homepage entry points
- cover the new docs routes in tests and update the spec

## Validation
- go test ./...

Refs #2