### PR TITLE
Add server timeouts, logging, and graceful shutdown

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 bin/
-server
+/server
 data/*.db
 data/*.db-*
 .DS_Store

--- a/README.md
+++ b/README.md
@@ -30,6 +30,11 @@ Environment variables:
 - `DATABASE_PATH`: SQLite database path, default `data/connectplus.db`.
 - `ADMIN_TOKEN`: enables protected lead viewing and CSV export.
 
+Runtime behavior:
+
+- HTTP server uses read, write, and idle timeouts for a safer default operational baseline.
+- `SIGINT` and `SIGTERM` trigger graceful shutdown with a bounded drain window before exit.
+
 ## Routes
 
 - `GET /`

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -1,0 +1,123 @@
+package main
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"log"
+	"net/http"
+	"os"
+	"os/signal"
+	"path/filepath"
+	"syscall"
+	"time"
+
+	"realtek-connect/internal/leads"
+	"realtek-connect/internal/web"
+
+	_ "modernc.org/sqlite"
+)
+
+func main() {
+	logger := log.New(os.Stdout, "", log.LstdFlags)
+
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer stop()
+
+	if err := run(ctx, logger); err != nil {
+		logger.Printf("server exited with error: %v", err)
+		os.Exit(1)
+	}
+}
+
+func run(ctx context.Context, logger *log.Logger) error {
+	if logger == nil {
+		logger = log.New(os.Stdout, "", log.LstdFlags)
+	}
+
+	databasePath := envOrDefault("DATABASE_PATH", "data/connectplus.db")
+	if err := os.MkdirAll(filepath.Dir(databasePath), 0o755); err != nil {
+		return err
+	}
+
+	db, err := sql.Open("sqlite", databasePath)
+	if err != nil {
+		return err
+	}
+	defer db.Close()
+
+	if err := db.PingContext(ctx); err != nil {
+		return err
+	}
+
+	repository := leads.NewRepository(db)
+	if err := repository.Init(); err != nil {
+		return err
+	}
+
+	application, err := web.NewServer(web.Config{
+		LeadStore:  repository,
+		AdminToken: os.Getenv("ADMIN_TOKEN"),
+	})
+	if err != nil {
+		return err
+	}
+
+	address := ":" + envOrDefault("PORT", "8080")
+	server := web.NewHTTPServer(web.HTTPServerConfig{
+		Addr:    address,
+		Handler: web.LoggingMiddleware(logger)(application.Routes()),
+	})
+
+	logger.Printf("listening on %s", address)
+
+	return serveWithGracefulShutdown(ctx, server, logger, web.DefaultShutdownTimeout)
+}
+
+type httpServerLifecycle interface {
+	ListenAndServe() error
+	Shutdown(context.Context) error
+}
+
+func serveWithGracefulShutdown(ctx context.Context, server httpServerLifecycle, logger *log.Logger, shutdownTimeout time.Duration) error {
+	if logger == nil {
+		logger = log.New(os.Stdout, "", log.LstdFlags)
+	}
+
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- server.ListenAndServe()
+	}()
+
+	select {
+	case err := <-errCh:
+		if err != nil && !errors.Is(err, http.ErrServerClosed) {
+			return err
+		}
+		return nil
+	case <-ctx.Done():
+		logger.Printf("shutdown requested")
+	}
+
+	shutdownCtx, cancel := context.WithTimeout(context.Background(), shutdownTimeout)
+	defer cancel()
+
+	if err := server.Shutdown(shutdownCtx); err != nil {
+		return err
+	}
+
+	if err := <-errCh; err != nil && !errors.Is(err, http.ErrServerClosed) {
+		return err
+	}
+
+	logger.Printf("shutdown complete")
+	return nil
+}
+
+func envOrDefault(key, fallback string) string {
+	value := os.Getenv(key)
+	if value == "" {
+		return fallback
+	}
+	return value
+}

--- a/cmd/server/main_test.go
+++ b/cmd/server/main_test.go
@@ -1,0 +1,87 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"io"
+	"log"
+	"net/http"
+	"testing"
+	"time"
+)
+
+type fakeServer struct {
+	listenStarted  chan struct{}
+	shutdownCalled chan struct{}
+	listenErr      error
+	shutdownErr    error
+}
+
+func newFakeServer(listenErr error, shutdownErr error) *fakeServer {
+	return &fakeServer{
+		listenStarted:  make(chan struct{}),
+		shutdownCalled: make(chan struct{}),
+		listenErr:      listenErr,
+		shutdownErr:    shutdownErr,
+	}
+}
+
+func (s *fakeServer) ListenAndServe() error {
+	close(s.listenStarted)
+	<-s.shutdownCalled
+	if s.listenErr != nil {
+		return s.listenErr
+	}
+	return http.ErrServerClosed
+}
+
+func (s *fakeServer) Shutdown(context.Context) error {
+	close(s.shutdownCalled)
+	return s.shutdownErr
+}
+
+func TestServeWithGracefulShutdownStopsServerOnContextCancel(t *testing.T) {
+	server := newFakeServer(nil, nil)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	done := make(chan error, 1)
+	go func() {
+		done <- serveWithGracefulShutdown(ctx, server, log.New(io.Discard, "", 0), time.Second)
+	}()
+
+	<-server.listenStarted
+	cancel()
+
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("serveWithGracefulShutdown returned error: %v", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("serveWithGracefulShutdown did not return")
+	}
+}
+
+func TestServeWithGracefulShutdownReturnsListenErrors(t *testing.T) {
+	server := newFakeServer(errors.New("listen failed"), nil)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	done := make(chan error, 1)
+	go func() {
+		done <- serveWithGracefulShutdown(ctx, server, log.New(io.Discard, "", 0), time.Second)
+	}()
+
+	<-server.listenStarted
+	close(server.shutdownCalled)
+
+	select {
+	case err := <-done:
+		if err == nil || err.Error() != "listen failed" {
+			t.Fatalf("error = %v, want listen failed", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("serveWithGracefulShutdown did not return")
+	}
+}

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -13,6 +13,7 @@ The current project status is **v0.1 Marketing Foundation**. It is a working web
 Implemented today:
 
 - Go HTTP server using `net/http`.
+- Runtime entrypoint under `cmd/server` with request logging, graceful shutdown, and baseline read/write/idle timeouts.
 - Server-rendered pages using `html/template`.
 - Static CSS with a Realtek-style white, deep navy, and blue-green/teal visual system.
 - Generated hero/platform image stored in `static/assets/connectplus-hero.png`.
@@ -134,6 +135,12 @@ Environment:
 - `PORT`, default `8080`.
 - `DATABASE_PATH`, default `data/connectplus.db`.
 - `ADMIN_TOKEN`, optional. When set, enables protected lead review and CSV export.
+
+Operational behavior:
+
+- The runtime uses configured `http.Server` read, write, and idle timeouts.
+- Requests are logged with method, path, response status, and elapsed time.
+- `SIGINT` and `SIGTERM` trigger graceful shutdown with a bounded timeout.
 
 Commands:
 

--- a/internal/web/runtime.go
+++ b/internal/web/runtime.go
@@ -1,0 +1,78 @@
+package web
+
+import (
+	"io"
+	"log"
+	"net/http"
+	"time"
+)
+
+const (
+	DefaultReadTimeout     = 5 * time.Second
+	DefaultWriteTimeout    = 15 * time.Second
+	DefaultIdleTimeout     = 60 * time.Second
+	DefaultShutdownTimeout = 10 * time.Second
+)
+
+type HTTPServerConfig struct {
+	Addr         string
+	Handler      http.Handler
+	ReadTimeout  time.Duration
+	WriteTimeout time.Duration
+	IdleTimeout  time.Duration
+}
+
+func NewHTTPServer(cfg HTTPServerConfig) *http.Server {
+	readTimeout := cfg.ReadTimeout
+	if readTimeout <= 0 {
+		readTimeout = DefaultReadTimeout
+	}
+
+	writeTimeout := cfg.WriteTimeout
+	if writeTimeout <= 0 {
+		writeTimeout = DefaultWriteTimeout
+	}
+
+	idleTimeout := cfg.IdleTimeout
+	if idleTimeout <= 0 {
+		idleTimeout = DefaultIdleTimeout
+	}
+
+	return &http.Server{
+		Addr:         cfg.Addr,
+		Handler:      cfg.Handler,
+		ReadTimeout:  readTimeout,
+		WriteTimeout: writeTimeout,
+		IdleTimeout:  idleTimeout,
+	}
+}
+
+func LoggingMiddleware(logger *log.Logger) func(http.Handler) http.Handler {
+	if logger == nil {
+		logger = log.New(io.Discard, "", 0)
+	}
+
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			started := time.Now()
+			recorder := &statusRecorder{
+				ResponseWriter: w,
+				status:         http.StatusOK,
+			}
+
+			next.ServeHTTP(recorder, r)
+
+			logger.Printf("%s %s %d %s", r.Method, r.URL.RequestURI(), recorder.status, time.Since(started).Round(time.Millisecond))
+		})
+	}
+}
+
+type statusRecorder struct {
+	http.ResponseWriter
+	status int
+}
+
+func (r *statusRecorder) WriteHeader(status int) {
+	r.status = status
+	r.ResponseWriter.WriteHeader(status)
+}

--- a/internal/web/runtime_test.go
+++ b/internal/web/runtime_test.go
@@ -1,0 +1,73 @@
+package web
+
+import (
+	"bytes"
+	"log"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestNewHTTPServerAppliesDefaultTimeouts(t *testing.T) {
+	server := NewHTTPServer(HTTPServerConfig{
+		Addr:    ":8080",
+		Handler: http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {}),
+	})
+
+	if server.ReadTimeout != DefaultReadTimeout {
+		t.Fatalf("read timeout = %s, want %s", server.ReadTimeout, DefaultReadTimeout)
+	}
+	if server.WriteTimeout != DefaultWriteTimeout {
+		t.Fatalf("write timeout = %s, want %s", server.WriteTimeout, DefaultWriteTimeout)
+	}
+	if server.IdleTimeout != DefaultIdleTimeout {
+		t.Fatalf("idle timeout = %s, want %s", server.IdleTimeout, DefaultIdleTimeout)
+	}
+}
+
+func TestNewHTTPServerUsesExplicitTimeouts(t *testing.T) {
+	server := NewHTTPServer(HTTPServerConfig{
+		Addr:         ":8080",
+		Handler:      http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {}),
+		ReadTimeout:  2 * time.Second,
+		WriteTimeout: 3 * time.Second,
+		IdleTimeout:  4 * time.Second,
+	})
+
+	if server.ReadTimeout != 2*time.Second {
+		t.Fatalf("read timeout = %s, want 2s", server.ReadTimeout)
+	}
+	if server.WriteTimeout != 3*time.Second {
+		t.Fatalf("write timeout = %s, want 3s", server.WriteTimeout)
+	}
+	if server.IdleTimeout != 4*time.Second {
+		t.Fatalf("idle timeout = %s, want 4s", server.IdleTimeout)
+	}
+}
+
+func TestLoggingMiddlewareLogsRequestOutcome(t *testing.T) {
+	var output bytes.Buffer
+	logger := log.New(&output, "", 0)
+
+	handler := LoggingMiddleware(logger)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/healthz" {
+			t.Fatalf("path = %s, want /healthz", r.URL.Path)
+		}
+		w.WriteHeader(http.StatusNoContent)
+	}))
+
+	req := httptest.NewRequest(http.MethodGet, "/healthz?check=1", nil)
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusNoContent {
+		t.Fatalf("status = %d, want 204", rec.Code)
+	}
+
+	logLine := output.String()
+	if !strings.Contains(logLine, "GET /healthz?check=1 204") {
+		t.Fatalf("log line = %q, want method, path, and status", logLine)
+	}
+}


### PR DESCRIPTION
## Summary
- add a runnable `cmd/server` entrypoint backed by SQLite lead initialization
- wrap the app with timeout-configured `http.Server` construction and request logging middleware
- handle `SIGINT` and `SIGTERM` with graceful shutdown and cover the new runtime behavior in tests

## Validation
- go test ./...
- go build ./cmd/server

Refs #17