### PR TITLE
Add SEO metadata and crawl endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Realtek Connect+ is a Go-rendered HTTP website for a Realtek-style IoT cloud pla
 
 Current status: **v0.1 Marketing Foundation**.
 
-This repository currently contains a working marketing website foundation, a developer docs portal structure, contact lead capture, SQLite storage, admin lead review, CSV export, and health check. It is not yet a complete ESP RainMaker parity website, IoT console, user authentication service, real OTA service, device provisioning backend, or telemetry platform.
+This repository currently contains a working marketing website foundation, a developer docs portal structure, per-page SEO/social metadata, sitemap and robots endpoints, contact lead capture, SQLite storage, admin lead review, CSV export, and health check. It is not yet a complete ESP RainMaker parity website, IoT console, user authentication service, real OTA service, device provisioning backend, or telemetry platform.
 
 The full roadmap and developer issue backlog live in [`docs/SPEC.md`](docs/SPEC.md).
 
@@ -38,6 +38,8 @@ Environment variables:
 - `GET /features`
 - `GET /features/{slug}`
 - `GET /contact`
+- `GET /robots.txt`
+- `GET /sitemap.xml`
 - `POST /contact`
 - `GET /healthz`
 - `GET /admin/leads`, requires `ADMIN_TOKEN`

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -16,8 +16,10 @@ Implemented today:
 - Server-rendered pages using `html/template`.
 - Static CSS with a Realtek-style white, deep navy, and blue-green/teal visual system.
 - Generated hero/platform image stored in `static/assets/connectplus-hero.png`.
+- Per-page title, description, canonical, Open Graph, and Twitter card metadata.
 - Developer docs landing and detail pages covering Product Overview, Development, APIs, SDKs, Firmware, CLI, Deployment, and Release Notes.
 - Feature overview and detail pages for Provision, OTA, Fleet Management, App SDK, Insights, Private Cloud, and Integrations.
+- `robots.txt` and `sitemap.xml` routes for crawl and link discovery.
 - Contact / early access registration form.
 - SQLite lead capture through `DATABASE_PATH`, defaulting to `data/connectplus.db`.
 - Protected admin lead review and CSV export when `ADMIN_TOKEN` is set.
@@ -31,6 +33,8 @@ Current routes:
 - `GET /features`
 - `GET /features/{slug}`
 - `GET /contact`
+- `GET /robots.txt`
+- `GET /sitemap.xml`
 - `POST /contact`
 - `GET /healthz`
 - `GET /admin/leads`
@@ -98,7 +102,7 @@ Status values:
 | Private Cloud / Deployment | Content Partial | Add public evaluation vs private commercial deployment, data ownership, custom domain, regional deployment, deployment FAQ, upgrade path, and production support story. |
 | Matter / Ecosystem Integrations | Content Partial | Add Matter ecosystem positioning, Matter Fabric concept, voice assistants, MQTT over TLS, REST APIs, webhooks, cloud-to-cloud integration, and protocol diagrams. |
 | Developer Docs / APIs / SDKs / CLI | Content Partial | Docs portal structure now exists across Product Overview, Development, APIs, SDKs, Firmware, CLI, Deployment, and Release Notes; deeper implementation detail and reference content still needs follow-on work. |
-| SEO / Launch Readiness | Planned | Add metadata, sitemap, robots, accessibility pass, visual smoke checks, deployment packaging, and CI. |
+| SEO / Launch Readiness | Content Partial | Metadata, sitemap, and robots now exist; remaining work includes accessibility pass, visual smoke checks, deployment packaging, and CI. |
 | Real IoT Cloud Operations | Out of Scope for website v1 | The public website will describe platform capabilities; it will not implement real device provisioning, OTA delivery, user auth, or telemetry ingestion in v1. |
 
 ## Website Completion Roadmap
@@ -118,6 +122,8 @@ Routes:
 - `GET /features`: feature overview.
 - `GET /features/{slug}`: feature detail pages.
 - `GET /contact`: contact / early access registration form.
+- `GET /robots.txt`: crawl directives for search bots.
+- `GET /sitemap.xml`: sitemap covering public marketing and docs pages.
 - `POST /contact`: validate and store a lead in SQLite.
 - `GET /healthz`: plain-text health check.
 - `GET /admin/leads`: protected lead review page, enabled only when `ADMIN_TOKEN` is set.
@@ -192,7 +198,7 @@ Contact form fields:
 ## Test Plan
 
 - `go test ./...`
-- HTTP route tests for `/`, `/features`, all feature detail pages, and `/contact`.
+- HTTP route tests for `/`, `/docs`, `/features`, feature/detail pages, `/contact`, `/robots.txt`, and `/sitemap.xml`.
 - Unknown feature slug returns 404.
 - Valid contact POST writes SQLite and shows success.
 - Invalid contact POST shows validation errors and does not write a lead.

--- a/internal/web/metadata.go
+++ b/internal/web/metadata.go
@@ -1,0 +1,130 @@
+package web
+
+import (
+	"encoding/xml"
+	"net/http"
+	"strings"
+
+	"realtek-connect/internal/docs"
+	"realtek-connect/internal/features"
+)
+
+const (
+	heroImagePath = "/static/assets/connectplus-hero.png"
+	heroImageAlt  = "Realtek Connect+ device, cloud, mobile app, and dashboard platform flow"
+)
+
+type sitemapURLSet struct {
+	XMLName xml.Name     `xml:"urlset"`
+	XMLNS   string       `xml:"xmlns,attr"`
+	URLs    []sitemapURL `xml:"url"`
+}
+
+type sitemapURL struct {
+	Loc string `xml:"loc"`
+}
+
+func (s *Server) basePageData(r *http.Request, title, description string) pageData {
+	return pageData{
+		Title:           title,
+		MetaDescription: description,
+		CanonicalURL:    absoluteURL(r, r.URL.Path),
+		SocialImageURL:  absoluteURL(r, heroImagePath),
+		SocialImageAlt:  heroImageAlt,
+		CurrentPath:     r.URL.Path,
+		Docs:            docs.All(),
+		Features:        features.All(),
+	}
+}
+
+func (s *Server) adminPageData(r *http.Request, title, description string) pageData {
+	data := s.basePageData(r, title, description)
+	data.MetaRobots = "noindex, nofollow"
+	return data
+}
+
+func (s *Server) handleRobotsTxt(w http.ResponseWriter, r *http.Request) {
+	if r.URL.Path != "/robots.txt" {
+		http.NotFound(w, r)
+		return
+	}
+	if r.Method != http.MethodGet {
+		methodNotAllowed(w)
+		return
+	}
+
+	body := strings.Join([]string{
+		"User-agent: *",
+		"Allow: /",
+		"Disallow: /admin/",
+		"Disallow: /healthz",
+		"Sitemap: " + absoluteURL(r, "/sitemap.xml"),
+		"",
+	}, "\n")
+
+	w.Header().Set("Content-Type", "text/plain; charset=utf-8")
+	w.WriteHeader(http.StatusOK)
+	_, _ = w.Write([]byte(body))
+}
+
+func (s *Server) handleSitemapXML(w http.ResponseWriter, r *http.Request) {
+	if r.URL.Path != "/sitemap.xml" {
+		http.NotFound(w, r)
+		return
+	}
+	if r.Method != http.MethodGet {
+		methodNotAllowed(w)
+		return
+	}
+
+	paths := []string{"/", "/docs", "/features", "/contact"}
+	for _, section := range docs.All() {
+		paths = append(paths, "/docs/"+section.Slug)
+	}
+	for _, feature := range features.All() {
+		paths = append(paths, "/features/"+feature.Slug)
+	}
+
+	payload := sitemapURLSet{
+		XMLNS: "http://www.sitemaps.org/schemas/sitemap/0.9",
+		URLs:  make([]sitemapURL, 0, len(paths)),
+	}
+	for _, path := range paths {
+		payload.URLs = append(payload.URLs, sitemapURL{Loc: absoluteURL(r, path)})
+	}
+
+	body, err := xml.MarshalIndent(payload, "", "  ")
+	if err != nil {
+		http.Error(w, "could not build sitemap", http.StatusInternalServerError)
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/xml; charset=utf-8")
+	w.WriteHeader(http.StatusOK)
+	_, _ = w.Write([]byte(xml.Header))
+	_, _ = w.Write(body)
+	_, _ = w.Write([]byte("\n"))
+}
+
+func absoluteURL(r *http.Request, path string) string {
+	host := strings.TrimSpace(r.Header.Get("X-Forwarded-Host"))
+	if host == "" {
+		host = r.Host
+	}
+	if host == "" {
+		host = "localhost"
+	}
+
+	return requestScheme(r) + "://" + host + path
+}
+
+func requestScheme(r *http.Request) string {
+	forwarded := strings.TrimSpace(r.Header.Get("X-Forwarded-Proto"))
+	if forwarded != "" {
+		return strings.TrimSpace(strings.Split(forwarded, ",")[0])
+	}
+	if r.TLS != nil {
+		return "https"
+	}
+	return "http"
+}

--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -37,19 +37,24 @@ type Server struct {
 }
 
 type pageData struct {
-	Title        string
-	CurrentPath  string
-	Docs         []docs.Section
-	Doc          docs.Section
-	Features     []features.Feature
-	Feature      features.Feature
-	Form         contactForm
-	Errors       map[string]string
-	Success      bool
-	SubmittedFor string
-	Leads        []leads.LeadRecord
-	AdminEnabled bool
-	AdminCSVHref string
+	Title           string
+	MetaDescription string
+	CanonicalURL    string
+	SocialImageURL  string
+	SocialImageAlt  string
+	MetaRobots      string
+	CurrentPath     string
+	Docs            []docs.Section
+	Doc             docs.Section
+	Features        []features.Feature
+	Feature         features.Feature
+	Form            contactForm
+	Errors          map[string]string
+	Success         bool
+	SubmittedFor    string
+	Leads           []leads.LeadRecord
+	AdminEnabled    bool
+	AdminCSVHref    string
 }
 
 type contactForm struct {
@@ -78,6 +83,8 @@ func NewServer(cfg Config) (*Server, error) {
 func (s *Server) Routes() http.Handler {
 	mux := http.NewServeMux()
 	mux.Handle("/static/", http.StripPrefix("/static/", http.FileServer(http.Dir(s.staticDir))))
+	mux.HandleFunc("/robots.txt", s.handleRobotsTxt)
+	mux.HandleFunc("/sitemap.xml", s.handleSitemapXML)
 	mux.HandleFunc("/", s.handleHome)
 	mux.HandleFunc("/docs", s.handleDocs)
 	mux.HandleFunc("/docs/", s.handleDocDetail)
@@ -99,12 +106,11 @@ func (s *Server) handleHome(w http.ResponseWriter, r *http.Request) {
 		methodNotAllowed(w)
 		return
 	}
-	s.render(w, http.StatusOK, "home.html", pageData{
-		Title:       "Realtek Connect+ | IoT Cloud Platform",
-		CurrentPath: r.URL.Path,
-		Docs:        docs.All(),
-		Features:    features.All(),
-	})
+	s.render(w, http.StatusOK, "home.html", s.basePageData(
+		r,
+		"Realtek Connect+ | IoT Cloud Platform",
+		"Realtek Connect+ is an IoT cloud platform for provisioning, OTA, fleet management, app SDKs, insights, private cloud, and integrations.",
+	))
 }
 
 func (s *Server) handleDocs(w http.ResponseWriter, r *http.Request) {
@@ -116,12 +122,11 @@ func (s *Server) handleDocs(w http.ResponseWriter, r *http.Request) {
 		methodNotAllowed(w)
 		return
 	}
-	s.render(w, http.StatusOK, "docs.html", pageData{
-		Title:       "Developer Docs | Realtek Connect+",
-		CurrentPath: r.URL.Path,
-		Docs:        docs.All(),
-		Features:    features.All(),
-	})
+	s.render(w, http.StatusOK, "docs.html", s.basePageData(
+		r,
+		"Developer Docs | Realtek Connect+",
+		"Browse Realtek Connect+ documentation entry points for product overview, development, APIs, SDKs, firmware, CLI, deployment, and release notes.",
+	))
 }
 
 func (s *Server) handleDocDetail(w http.ResponseWriter, r *http.Request) {
@@ -143,13 +148,13 @@ func (s *Server) handleDocDetail(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	s.render(w, http.StatusOK, "doc.html", pageData{
-		Title:       doc.Title + " | Realtek Connect+ Docs",
-		CurrentPath: r.URL.Path,
-		Docs:        docs.All(),
-		Doc:         doc,
-		Features:    features.All(),
-	})
+	data := s.basePageData(
+		r,
+		doc.Title+" | Realtek Connect+ Docs",
+		doc.Summary,
+	)
+	data.Doc = doc
+	s.render(w, http.StatusOK, "doc.html", data)
 }
 
 func (s *Server) handleHealthz(w http.ResponseWriter, r *http.Request) {
@@ -175,12 +180,11 @@ func (s *Server) handleFeatures(w http.ResponseWriter, r *http.Request) {
 		methodNotAllowed(w)
 		return
 	}
-	s.render(w, http.StatusOK, "features.html", pageData{
-		Title:       "Features | Realtek Connect+",
-		CurrentPath: r.URL.Path,
-		Docs:        docs.All(),
-		Features:    features.All(),
-	})
+	s.render(w, http.StatusOK, "features.html", s.basePageData(
+		r,
+		"Features | Realtek Connect+",
+		"Explore provisioning, OTA, fleet management, app SDK, insights, private cloud, and ecosystem integrations for Realtek-based IoT products.",
+	))
 }
 
 func (s *Server) handleAdminLeads(w http.ResponseWriter, r *http.Request) {
@@ -205,14 +209,15 @@ func (s *Server) handleAdminLeads(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	s.render(w, http.StatusOK, "admin_leads.html", pageData{
-		Title:        "Leads | Realtek Connect+",
-		CurrentPath:  r.URL.Path,
-		Features:     features.All(),
-		Leads:        records,
-		AdminEnabled: s.adminToken != "",
-		AdminCSVHref: s.adminCSVHref(r),
-	})
+	data := s.adminPageData(
+		r,
+		"Leads | Realtek Connect+",
+		"Protected Realtek Connect+ lead review interface.",
+	)
+	data.Leads = records
+	data.AdminEnabled = s.adminToken != ""
+	data.AdminCSVHref = s.adminCSVHref(r)
+	s.render(w, http.StatusOK, "admin_leads.html", data)
 }
 
 func (s *Server) handleAdminLeadsCSV(w http.ResponseWriter, r *http.Request) {
@@ -303,24 +308,23 @@ func (s *Server) handleFeatureDetail(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	s.render(w, http.StatusOK, "feature.html", pageData{
-		Title:       feature.Title + " | Realtek Connect+",
-		CurrentPath: r.URL.Path,
-		Docs:        docs.All(),
-		Feature:     feature,
-		Features:    features.All(),
-	})
+	data := s.basePageData(
+		r,
+		feature.Title+" | Realtek Connect+",
+		feature.Summary,
+	)
+	data.Feature = feature
+	s.render(w, http.StatusOK, "feature.html", data)
 }
 
 func (s *Server) handleContact(w http.ResponseWriter, r *http.Request) {
 	switch r.Method {
 	case http.MethodGet:
-		s.render(w, http.StatusOK, "contact.html", pageData{
-			Title:       "Contact | Realtek Connect+",
-			CurrentPath: r.URL.Path,
-			Docs:        docs.All(),
-			Features:    features.All(),
-		})
+		s.render(w, http.StatusOK, "contact.html", s.basePageData(
+			r,
+			"Contact | Realtek Connect+",
+			"Contact the Realtek Connect+ team about provisioning, OTA, fleet operations, app SDKs, insights, or private cloud evaluation.",
+		))
 	case http.MethodPost:
 		s.submitContact(w, r)
 	default:
@@ -344,14 +348,14 @@ func (s *Server) submitContact(w http.ResponseWriter, r *http.Request) {
 
 	errors := validateContact(form)
 	if len(errors) > 0 {
-		s.render(w, http.StatusBadRequest, "contact.html", pageData{
-			Title:       "Contact | Realtek Connect+",
-			CurrentPath: r.URL.Path,
-			Docs:        docs.All(),
-			Features:    features.All(),
-			Form:        form,
-			Errors:      errors,
-		})
+		data := s.basePageData(
+			r,
+			"Contact | Realtek Connect+",
+			"Contact the Realtek Connect+ team about provisioning, OTA, fleet operations, app SDKs, insights, or private cloud evaluation.",
+		)
+		data.Form = form
+		data.Errors = errors
+		s.render(w, http.StatusBadRequest, "contact.html", data)
 		return
 	}
 
@@ -371,14 +375,14 @@ func (s *Server) submitContact(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	s.render(w, http.StatusOK, "contact.html", pageData{
-		Title:        "Contact | Realtek Connect+",
-		CurrentPath:  r.URL.Path,
-		Docs:         docs.All(),
-		Features:     features.All(),
-		Success:      true,
-		SubmittedFor: form.Name,
-	})
+	data := s.basePageData(
+		r,
+		"Contact | Realtek Connect+",
+		"Contact the Realtek Connect+ team about provisioning, OTA, fleet operations, app SDKs, insights, or private cloud evaluation.",
+	)
+	data.Success = true
+	data.SubmittedFor = form.Name
+	s.render(w, http.StatusOK, "contact.html", data)
 }
 
 func validateContact(form contactForm) map[string]string {

--- a/internal/web/server_test.go
+++ b/internal/web/server_test.go
@@ -58,7 +58,7 @@ func testServerWithAdminToken(t *testing.T, store LeadStore, adminToken string) 
 
 func TestRoutesReturnOK(t *testing.T) {
 	handler := testServer(t, &memoryLeadStore{})
-	paths := []string{"/", "/docs", "/features", "/contact", "/healthz"}
+	paths := []string{"/", "/docs", "/features", "/contact", "/healthz", "/robots.txt", "/sitemap.xml"}
 	for _, section := range docs.All() {
 		paths = append(paths, "/docs/"+section.Slug)
 	}
@@ -73,6 +73,114 @@ func TestRoutesReturnOK(t *testing.T) {
 		if rec.Code != http.StatusOK {
 			t.Fatalf("%s returned %d, want 200", path, rec.Code)
 		}
+	}
+}
+
+func TestHomeMetadataIncludesSocialTags(t *testing.T) {
+	handler := testServer(t, &memoryLeadStore{})
+
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", rec.Code)
+	}
+
+	body := rec.Body.String()
+	for _, want := range []string{
+		"<title>Realtek Connect&#43; | IoT Cloud Platform</title>",
+		`<meta name="description" content="Realtek Connect&#43; is an IoT cloud platform for provisioning, OTA, fleet management, app SDKs, insights, private cloud, and integrations.">`,
+		`<link rel="canonical" href="http://example.com/">`,
+		`<meta property="og:title" content="Realtek Connect&#43; | IoT Cloud Platform">`,
+		`<meta property="og:url" content="http://example.com/">`,
+		`<meta property="og:image" content="http://example.com/static/assets/connectplus-hero.png">`,
+		`<meta name="twitter:card" content="summary_large_image">`,
+	} {
+		if !strings.Contains(body, want) {
+			t.Fatalf("response does not contain %q: %s", want, body)
+		}
+	}
+}
+
+func TestFeatureMetadataUsesFeatureSummary(t *testing.T) {
+	handler := testServer(t, &memoryLeadStore{})
+
+	req := httptest.NewRequest(http.MethodGet, "/features/ota", nil)
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", rec.Code)
+	}
+
+	body := rec.Body.String()
+	for _, want := range []string{
+		`<title>OTA | Realtek Connect&#43;</title>`,
+		`<meta name="description" content="Upload firmware, create rollout campaigns, monitor jobs, and protect devices with version validation.">`,
+		`<meta property="og:url" content="http://example.com/features/ota">`,
+		`<meta name="twitter:title" content="OTA | Realtek Connect&#43;">`,
+	} {
+		if !strings.Contains(body, want) {
+			t.Fatalf("response does not contain %q: %s", want, body)
+		}
+	}
+}
+
+func TestRobotsTxtIncludesSitemap(t *testing.T) {
+	handler := testServer(t, &memoryLeadStore{})
+
+	req := httptest.NewRequest(http.MethodGet, "/robots.txt", nil)
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", rec.Code)
+	}
+	if got := rec.Header().Get("Content-Type"); !strings.Contains(got, "text/plain") {
+		t.Fatalf("content type = %q, want text/plain", got)
+	}
+
+	body := rec.Body.String()
+	for _, want := range []string{
+		"User-agent: *",
+		"Disallow: /admin/",
+		"Sitemap: http://example.com/sitemap.xml",
+	} {
+		if !strings.Contains(body, want) {
+			t.Fatalf("robots.txt does not contain %q: %s", want, body)
+		}
+	}
+}
+
+func TestSitemapXMLIncludesPublicRoutes(t *testing.T) {
+	handler := testServer(t, &memoryLeadStore{})
+
+	req := httptest.NewRequest(http.MethodGet, "/sitemap.xml", nil)
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", rec.Code)
+	}
+	if got := rec.Header().Get("Content-Type"); !strings.Contains(got, "application/xml") {
+		t.Fatalf("content type = %q, want application/xml", got)
+	}
+
+	body := rec.Body.String()
+	for _, want := range []string{
+		`<?xml version="1.0" encoding="UTF-8"?>`,
+		`<loc>http://example.com/</loc>`,
+		`<loc>http://example.com/docs/product-overview</loc>`,
+		`<loc>http://example.com/features/ota</loc>`,
+		`<loc>http://example.com/contact</loc>`,
+	} {
+		if !strings.Contains(body, want) {
+			t.Fatalf("sitemap does not contain %q: %s", want, body)
+		}
+	}
+	if strings.Contains(body, "/admin/leads") {
+		t.Fatalf("sitemap should not contain admin routes: %s", body)
 	}
 }
 

--- a/templates/layout.html
+++ b/templates/layout.html
@@ -5,7 +5,21 @@
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>{{.Title}}</title>
-  <meta name="description" content="Realtek Connect+ is an IoT cloud platform for provisioning, OTA, fleet management, app SDKs, insights, private cloud, and integrations.">
+  <meta name="description" content="{{.MetaDescription}}">
+  <link rel="canonical" href="{{.CanonicalURL}}">
+  <meta property="og:site_name" content="Realtek Connect+">
+  <meta property="og:type" content="website">
+  <meta property="og:title" content="{{.Title}}">
+  <meta property="og:description" content="{{.MetaDescription}}">
+  <meta property="og:url" content="{{.CanonicalURL}}">
+  <meta property="og:image" content="{{.SocialImageURL}}">
+  <meta property="og:image:alt" content="{{.SocialImageAlt}}">
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="{{.Title}}">
+  <meta name="twitter:description" content="{{.MetaDescription}}">
+  <meta name="twitter:image" content="{{.SocialImageURL}}">
+  <meta name="twitter:image:alt" content="{{.SocialImageAlt}}">
+  {{if .MetaRobots}}<meta name="robots" content="{{.MetaRobots}}">{{end}}
   <link rel="stylesheet" href="/static/styles.css">
 </head>
 <body>


### PR DESCRIPTION
## Summary
- add route-aware page metadata for titles, descriptions, canonical URLs, and Open Graph/Twitter tags
- serve robots.txt and sitemap.xml from the Go app using existing docs and feature route data
- document the new crawl routes and extend route-level tests for metadata and sitemap coverage

## Validation
- go test ./...
- go build ./...

Refs #11