### PR TITLE
Redact sensitive request log query parameters

### DIFF
--- a/internal/web/runtime.go
+++ b/internal/web/runtime.go
@@ -4,6 +4,8 @@ import (
 	"io"
 	"log"
 	"net/http"
+	"net/url"
+	"strings"
 	"time"
 )
 
@@ -62,8 +64,47 @@ func LoggingMiddleware(logger *log.Logger) func(http.Handler) http.Handler {
 
 			next.ServeHTTP(recorder, r)
 
-			logger.Printf("%s %s %d %s", r.Method, r.URL.RequestURI(), recorder.status, time.Since(started).Round(time.Millisecond))
+			logger.Printf("%s %s %d %s", r.Method, sanitizedRequestURI(r.URL), recorder.status, time.Since(started).Round(time.Millisecond))
 		})
+	}
+}
+
+func sanitizedRequestURI(requestURL *url.URL) string {
+	if requestURL == nil {
+		return ""
+	}
+	if requestURL.RawQuery == "" {
+		return requestURL.RequestURI()
+	}
+
+	values, err := url.ParseQuery(requestURL.RawQuery)
+	if err != nil {
+		return requestURL.EscapedPath()
+	}
+
+	redacted := false
+	for key := range values {
+		if !isSensitiveQueryParam(key) {
+			continue
+		}
+		values.Set(key, "REDACTED")
+		redacted = true
+	}
+	if !redacted {
+		return requestURL.RequestURI()
+	}
+
+	sanitized := *requestURL
+	sanitized.RawQuery = values.Encode()
+	return sanitized.RequestURI()
+}
+
+func isSensitiveQueryParam(key string) bool {
+	switch strings.ToLower(key) {
+	case "token", "access_token", "api_key", "apikey":
+		return true
+	default:
+		return false
 	}
 }
 

--- a/internal/web/runtime_test.go
+++ b/internal/web/runtime_test.go
@@ -71,3 +71,24 @@ func TestLoggingMiddlewareLogsRequestOutcome(t *testing.T) {
 		t.Fatalf("log line = %q, want method, path, and status", logLine)
 	}
 }
+
+func TestLoggingMiddlewareRedactsSensitiveQueryParameters(t *testing.T) {
+	var output bytes.Buffer
+	logger := log.New(&output, "", 0)
+
+	handler := LoggingMiddleware(logger)(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	req := httptest.NewRequest(http.MethodGet, "/admin/leads?token=secret&view=full", nil)
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	logLine := output.String()
+	if strings.Contains(logLine, "secret") {
+		t.Fatalf("log line = %q, secret token leaked", logLine)
+	}
+	if !strings.Contains(logLine, "/admin/leads?token=REDACTED&view=full 200") {
+		t.Fatalf("log line = %q, want redacted token and preserved request details", logLine)
+	}
+}


### PR DESCRIPTION
## Summary
- redact sensitive token-like query parameters before request URIs are written to logs
- preserve ordinary request path and non-sensitive query context for runtime observability
- add regression coverage proving admin token values do not leak through request logging

## Validation
- go test ./internal/web
- go test ./...
- go build ./cmd/server

Refs #17