### PR TITLE
Harden contact lead submissions

### DIFF
--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/csv"
 	"html/template"
+	"net"
 	"net/http"
 	"net/url"
 	"path/filepath"
@@ -34,6 +35,7 @@ type Server struct {
 	staticDir    string
 	leadStore    LeadStore
 	adminToken   string
+	contactLimit *submissionRateLimiter
 }
 
 type pageData struct {
@@ -63,7 +65,16 @@ type contactForm struct {
 	Email    string
 	Interest string
 	Message  string
+	Website  string
 }
+
+const (
+	contactNameMaxLength     = 120
+	contactCompanyMaxLength  = 160
+	contactEmailMaxLength    = 254
+	contactInterestMaxLength = 120
+	contactMessageMaxLength  = 2000
+)
 
 func NewServer(cfg Config) (*Server, error) {
 	if cfg.TemplatesDir == "" {
@@ -77,6 +88,7 @@ func NewServer(cfg Config) (*Server, error) {
 		staticDir:    cfg.StaticDir,
 		leadStore:    cfg.LeadStore,
 		adminToken:   cfg.AdminToken,
+		contactLimit: newSubmissionRateLimiter(5, 10*time.Minute),
 	}, nil
 }
 
@@ -344,6 +356,21 @@ func (s *Server) submitContact(w http.ResponseWriter, r *http.Request) {
 		Email:    strings.TrimSpace(r.FormValue("email")),
 		Interest: strings.TrimSpace(r.FormValue("interest")),
 		Message:  strings.TrimSpace(r.FormValue("message")),
+		Website:  strings.TrimSpace(r.FormValue("website")),
+	}
+
+	if isSpamContact(form) {
+		data := s.basePageData(
+			r,
+			"Contact | Realtek Connect+",
+			"Contact the Realtek Connect+ team about provisioning, OTA, fleet operations, app SDKs, insights, or private cloud evaluation.",
+		)
+		data.Form = form
+		data.Errors = map[string]string{
+			"form": "Request could not be processed.",
+		}
+		s.render(w, http.StatusBadRequest, "contact.html", data)
+		return
 	}
 
 	errors := validateContact(form)
@@ -356,6 +383,20 @@ func (s *Server) submitContact(w http.ResponseWriter, r *http.Request) {
 		data.Form = form
 		data.Errors = errors
 		s.render(w, http.StatusBadRequest, "contact.html", data)
+		return
+	}
+
+	if s.contactLimit != nil && !s.contactLimit.Allow(contactSubmissionKey(r)) {
+		data := s.basePageData(
+			r,
+			"Contact | Realtek Connect+",
+			"Contact the Realtek Connect+ team about provisioning, OTA, fleet operations, app SDKs, insights, or private cloud evaluation.",
+		)
+		data.Form = form
+		data.Errors = map[string]string{
+			"form": "Too many requests from this address. Please wait a few minutes and try again.",
+		}
+		s.render(w, http.StatusTooManyRequests, "contact.html", data)
 		return
 	}
 
@@ -389,19 +430,57 @@ func validateContact(form contactForm) map[string]string {
 	errors := map[string]string{}
 	if form.Name == "" {
 		errors["name"] = "Name is required."
+	} else if len(form.Name) > contactNameMaxLength {
+		errors["name"] = "Name must be 120 characters or fewer."
 	}
 	if form.Email == "" {
 		errors["email"] = "Email is required."
 	} else if !emailPattern.MatchString(form.Email) {
 		errors["email"] = "Enter a valid email address."
+	} else if len(form.Email) > contactEmailMaxLength {
+		errors["email"] = "Email must be 254 characters or fewer."
 	}
 	if form.Interest == "" {
 		errors["interest"] = "Select an area of interest."
+	} else if len(form.Interest) > contactInterestMaxLength {
+		errors["interest"] = "Interest must be 120 characters or fewer."
+	}
+	if len(form.Company) > contactCompanyMaxLength {
+		errors["company"] = "Company must be 160 characters or fewer."
+	}
+	if len(form.Message) > contactMessageMaxLength {
+		errors["message"] = "Message must be 2000 characters or fewer."
 	}
 	return errors
 }
 
 var emailPattern = regexp.MustCompile(`^[^@\s]+@[^@\s]+\.[^@\s]+$`)
+
+func isSpamContact(form contactForm) bool {
+	return form.Website != ""
+}
+
+func contactSubmissionKey(r *http.Request) string {
+	if forwardedFor := strings.TrimSpace(r.Header.Get("X-Forwarded-For")); forwardedFor != "" {
+		parts := strings.Split(forwardedFor, ",")
+		if len(parts) > 0 {
+			if value := strings.TrimSpace(parts[0]); value != "" {
+				return value
+			}
+		}
+	}
+	if realIP := strings.TrimSpace(r.Header.Get("X-Real-IP")); realIP != "" {
+		return realIP
+	}
+	host, _, err := net.SplitHostPort(strings.TrimSpace(r.RemoteAddr))
+	if err == nil && host != "" {
+		return host
+	}
+	if value := strings.TrimSpace(r.RemoteAddr); value != "" {
+		return value
+	}
+	return "unknown"
+}
 
 func (s *Server) render(w http.ResponseWriter, status int, name string, data pageData) {
 	files := []string{

--- a/internal/web/server_test.go
+++ b/internal/web/server_test.go
@@ -7,6 +7,7 @@ import (
 	"net/url"
 	"strings"
 	"testing"
+	"time"
 
 	"realtek-connect/internal/docs"
 	"realtek-connect/internal/features"
@@ -44,16 +45,22 @@ func testServer(t *testing.T, store LeadStore) http.Handler {
 
 func testServerWithAdminToken(t *testing.T, store LeadStore, adminToken string) http.Handler {
 	t.Helper()
-	server, err := NewServer(Config{
+	server := newTestServer(t, Config{
 		TemplatesDir: "../../templates",
 		StaticDir:    "../../static",
 		LeadStore:    store,
 		AdminToken:   adminToken,
 	})
+	return server.Routes()
+}
+
+func newTestServer(t *testing.T, cfg Config) *Server {
+	t.Helper()
+	server, err := NewServer(cfg)
 	if err != nil {
 		t.Fatalf("new server: %v", err)
 	}
-	return server.Routes()
+	return server
 }
 
 func TestRoutesReturnOK(t *testing.T) {
@@ -260,6 +267,118 @@ func TestInvalidContactPostDoesNotStoreLead(t *testing.T) {
 	}
 	if !strings.Contains(rec.Body.String(), "Name is required") {
 		t.Fatalf("response does not contain validation error: %s", rec.Body.String())
+	}
+}
+
+func TestOversizedContactPostDoesNotStoreLead(t *testing.T) {
+	store := &memoryLeadStore{}
+	handler := testServer(t, store)
+
+	form := url.Values{
+		"name":     {strings.Repeat("N", contactNameMaxLength+1)},
+		"company":  {strings.Repeat("C", contactCompanyMaxLength+1)},
+		"email":    {"kevin@example.com"},
+		"interest": {"OTA"},
+		"message":  {strings.Repeat("M", contactMessageMaxLength+1)},
+	}
+	req := httptest.NewRequest(http.MethodPost, "/contact", strings.NewReader(form.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	rec := httptest.NewRecorder()
+
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400", rec.Code)
+	}
+	if len(store.leads) != 0 {
+		t.Fatalf("stored leads = %d, want 0", len(store.leads))
+	}
+	body := rec.Body.String()
+	if !strings.Contains(body, "Name must be 120 characters or fewer.") {
+		t.Fatalf("response does not contain name limit error: %s", body)
+	}
+	if !strings.Contains(body, "Company must be 160 characters or fewer.") {
+		t.Fatalf("response does not contain company limit error: %s", body)
+	}
+	if !strings.Contains(body, "Message must be 2000 characters or fewer.") {
+		t.Fatalf("response does not contain message limit error: %s", body)
+	}
+}
+
+func TestSpamContactPostDoesNotStoreLead(t *testing.T) {
+	store := &memoryLeadStore{}
+	handler := testServer(t, store)
+
+	form := url.Values{
+		"name":     {"Kevin Huang"},
+		"email":    {"kevin@example.com"},
+		"interest": {"OTA"},
+		"website":  {"https://spam.example.com"},
+	}
+	req := httptest.NewRequest(http.MethodPost, "/contact", strings.NewReader(form.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	rec := httptest.NewRecorder()
+
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400", rec.Code)
+	}
+	if len(store.leads) != 0 {
+		t.Fatalf("stored leads = %d, want 0", len(store.leads))
+	}
+	if !strings.Contains(rec.Body.String(), "Request could not be processed.") {
+		t.Fatalf("response does not contain form error: %s", rec.Body.String())
+	}
+}
+
+func TestContactPostRateLimitsRepeatedSubmissions(t *testing.T) {
+	store := &memoryLeadStore{}
+	server := newTestServer(t, Config{
+		TemplatesDir: "../../templates",
+		StaticDir:    "../../static",
+		LeadStore:    store,
+	})
+
+	now := time.Date(2026, 4, 28, 0, 0, 0, 0, time.UTC)
+	server.contactLimit = &submissionRateLimiter{
+		limit:  1,
+		window: time.Minute,
+		now:    func() time.Time { return now },
+		hits:   make(map[string][]time.Time),
+	}
+	handler := server.Routes()
+
+	form := url.Values{
+		"name":     {"Kevin Huang"},
+		"email":    {"kevin@example.com"},
+		"interest": {"OTA"},
+	}
+
+	firstReq := httptest.NewRequest(http.MethodPost, "/contact", strings.NewReader(form.Encode()))
+	firstReq.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	firstReq.RemoteAddr = "198.51.100.10:1234"
+	firstRec := httptest.NewRecorder()
+	handler.ServeHTTP(firstRec, firstReq)
+
+	if firstRec.Code != http.StatusOK {
+		t.Fatalf("first status = %d, want 200", firstRec.Code)
+	}
+
+	secondReq := httptest.NewRequest(http.MethodPost, "/contact", strings.NewReader(form.Encode()))
+	secondReq.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	secondReq.RemoteAddr = "198.51.100.10:1234"
+	secondRec := httptest.NewRecorder()
+	handler.ServeHTTP(secondRec, secondReq)
+
+	if secondRec.Code != http.StatusTooManyRequests {
+		t.Fatalf("second status = %d, want 429", secondRec.Code)
+	}
+	if len(store.leads) != 1 {
+		t.Fatalf("stored leads = %d, want 1", len(store.leads))
+	}
+	if !strings.Contains(secondRec.Body.String(), "Too many requests from this address.") {
+		t.Fatalf("response does not contain rate limit error: %s", secondRec.Body.String())
 	}
 }
 

--- a/internal/web/submission_rate_limit.go
+++ b/internal/web/submission_rate_limit.go
@@ -1,0 +1,55 @@
+package web
+
+import (
+	"sync"
+	"time"
+)
+
+type submissionRateLimiter struct {
+	mu     sync.Mutex
+	limit  int
+	window time.Duration
+	now    func() time.Time
+	hits   map[string][]time.Time
+}
+
+func newSubmissionRateLimiter(limit int, window time.Duration) *submissionRateLimiter {
+	return &submissionRateLimiter{
+		limit:  limit,
+		window: window,
+		now:    time.Now,
+		hits:   make(map[string][]time.Time),
+	}
+}
+
+func (l *submissionRateLimiter) Allow(key string) bool {
+	if l == nil || l.limit <= 0 || l.window <= 0 {
+		return true
+	}
+
+	now := l.now
+	if now == nil {
+		now = time.Now
+	}
+
+	l.mu.Lock()
+	defer l.mu.Unlock()
+
+	current := now()
+	cutoff := current.Add(-l.window)
+	timestamps := l.hits[key]
+	kept := timestamps[:0]
+	for _, ts := range timestamps {
+		if !ts.Before(cutoff) {
+			kept = append(kept, ts)
+		}
+	}
+	if len(kept) >= l.limit {
+		l.hits[key] = append([]time.Time(nil), kept...)
+		return false
+	}
+
+	kept = append(kept, current)
+	l.hits[key] = append([]time.Time(nil), kept...)
+	return true
+}

--- a/static/styles.css
+++ b/static/styles.css
@@ -496,6 +496,25 @@ label em {
   font-weight: 650;
 }
 
+.form-error {
+  margin: 0;
+  padding: 12px 14px;
+  border: 1px solid rgba(180, 35, 24, 0.2);
+  border-radius: 8px;
+  background: #fef3f2;
+  color: #b42318;
+  font-size: 0.95rem;
+  font-weight: 650;
+}
+
+.honeypot-field {
+  position: absolute;
+  left: -10000px;
+  width: 1px;
+  height: 1px;
+  overflow: hidden;
+}
+
 input,
 select,
 textarea {

--- a/templates/contact.html
+++ b/templates/contact.html
@@ -21,19 +21,25 @@
     </div>
     {{else}}
     <form method="post" action="/contact" novalidate>
+      {{with index .Errors "form"}}<p class="form-error" role="alert">{{.}}</p>{{end}}
+      <div class="honeypot-field" aria-hidden="true">
+        <label for="contact-website">Website</label>
+        <input id="contact-website" name="website" type="text" tabindex="-1" autocomplete="off">
+      </div>
       <label>
         <span>Name</span>
         {{with index .Errors "name"}}<em>{{.}}</em>{{end}}
-        <input name="name" value="{{.Form.Name}}" autocomplete="name" required>
+        <input name="name" value="{{.Form.Name}}" autocomplete="name" maxlength="120" required>
       </label>
       <label>
         <span>Company</span>
-        <input name="company" value="{{.Form.Company}}" autocomplete="organization">
+        {{with index .Errors "company"}}<em>{{.}}</em>{{end}}
+        <input name="company" value="{{.Form.Company}}" autocomplete="organization" maxlength="160">
       </label>
       <label>
         <span>Email</span>
         {{with index .Errors "email"}}<em>{{.}}</em>{{end}}
-        <input name="email" value="{{.Form.Email}}" type="email" autocomplete="email" required>
+        <input name="email" value="{{.Form.Email}}" type="email" autocomplete="email" maxlength="254" required>
       </label>
       <label>
         <span>Interest</span>
@@ -47,7 +53,8 @@
       </label>
       <label>
         <span>Message</span>
-        <textarea name="message" rows="5">{{.Form.Message}}</textarea>
+        {{with index .Errors "message"}}<em>{{.}}</em>{{end}}
+        <textarea name="message" rows="5" maxlength="2000">{{.Form.Message}}</textarea>
       </label>
       <button class="button primary" type="submit">Submit Request</button>
     </form>


### PR DESCRIPTION
## Summary
- add server-side max-length validation for contact lead fields and surface form-level errors
- reject honeypot-filled submissions and rate-limit repeated contact posts in memory before SQLite writes
- add regression coverage for valid, invalid, oversized, spam, and rate-limited submissions

## Validation
- go test ./...
- go build ./cmd/server

Refs #13