### PR TITLE
Add GitHub Actions CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,36 @@
+name: CI
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  verify:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: Check Go formatting
+        shell: bash
+        run: |
+          files="$(git ls-files '*.go')"
+          unformatted="$(gofmt -l $files)"
+          if [ -n "$unformatted" ]; then
+            echo "Unformatted Go files:"
+            echo "$unformatted"
+            exit 1
+          fi
+
+      - name: Run tests
+        run: go test ./...
+
+      - name: Build server
+        run: go build ./cmd/server


### PR DESCRIPTION
Refs #16

## Summary
- add a GitHub Actions CI workflow for push and pull request events
- fail CI when tracked Go files are not formatted with `gofmt`
- run `go test ./...` and `go build ./cmd/server` in the workflow

## Validation
- `gofmt -l $(git ls-files '*.go')`\n- `go test ./...`\n- `go build ./cmd/server`