### PR TITLE
Improve admin lead filtering and pagination

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Realtek Connect+ is a Go-rendered HTTP website for a Realtek-style IoT cloud pla
 
 Current status: **v0.1 Marketing Foundation**.
 
-This repository currently contains a working marketing website foundation, a developer docs portal structure, per-page SEO/social metadata, sitemap and robots endpoints, contact lead capture, SQLite storage, admin lead review, CSV export, health check, and a container deployment recipe. It is not yet a complete ESP RainMaker parity website, IoT console, user authentication service, real OTA service, device provisioning backend, or telemetry platform.
+This repository currently contains a working marketing website foundation, a developer docs portal structure, per-page SEO/social metadata, sitemap and robots endpoints, contact lead capture, SQLite storage, admin lead review with filtering and pagination, filtered CSV export, health check, and a container deployment recipe. It is not yet a complete ESP RainMaker parity website, IoT console, user authentication service, real OTA service, device provisioning backend, or telemetry platform.
 
 The full roadmap and developer issue backlog live in [`docs/SPEC.md`](docs/SPEC.md).
 

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -23,7 +23,7 @@ Implemented today:
 - `robots.txt` and `sitemap.xml` routes for crawl and link discovery.
 - Contact / early access registration form.
 - SQLite lead capture through `DATABASE_PATH`, defaulting to `data/connectplus.db`.
-- Protected admin lead review and CSV export when `ADMIN_TOKEN` is set.
+- Protected admin lead review with filtering, pagination, and filtered CSV export when `ADMIN_TOKEN` is set.
 - Plain-text `/healthz` endpoint.
 - Multi-stage Docker packaging that ships the server binary plus runtime templates/static assets and defaults SQLite storage to `/data/connectplus.db` inside the container.
 

--- a/internal/leads/repository.go
+++ b/internal/leads/repository.go
@@ -25,6 +25,18 @@ type LeadRecord struct {
 	CreatedAt time.Time
 }
 
+type ListFilter struct {
+	Email    string
+	Company  string
+	Interest string
+}
+
+type ListOptions struct {
+	Filter ListFilter
+	Limit  int
+	Offset int
+}
+
 type Repository struct {
 	db *sql.DB
 }
@@ -60,22 +72,19 @@ VALUES (?, ?, ?, ?, ?)`,
 	return err
 }
 
-func (r *Repository) Count(ctx context.Context) (int, error) {
+func (r *Repository) Count(ctx context.Context, filter ListFilter) (int, error) {
 	var count int
-	err := r.db.QueryRowContext(ctx, `SELECT COUNT(*) FROM leads`).Scan(&count)
+	query, args := leadListQuery(`SELECT COUNT(*) FROM leads`, filter, ListOptions{})
+	err := r.db.QueryRowContext(ctx, query, args...).Scan(&count)
 	return count, err
 }
 
-func (r *Repository) List(ctx context.Context, limit int) ([]LeadRecord, error) {
-	if limit <= 0 || limit > 500 {
-		limit = 100
-	}
-
-	rows, err := r.db.QueryContext(ctx, `
+func (r *Repository) List(ctx context.Context, opts ListOptions) ([]LeadRecord, error) {
+	opts = normalizeListOptions(opts)
+	query, args := leadListQuery(`
 SELECT id, name, company, email, interest, message, created_at
-FROM leads
-ORDER BY id DESC
-LIMIT ?`, limit)
+FROM leads`, opts.Filter, opts)
+	rows, err := r.db.QueryContext(ctx, query, args...)
 	if err != nil {
 		return nil, err
 	}
@@ -103,6 +112,61 @@ LIMIT ?`, limit)
 		return nil, err
 	}
 	return records, nil
+}
+
+func normalizeListOptions(opts ListOptions) ListOptions {
+	opts.Filter = ListFilter{
+		Email:    strings.TrimSpace(opts.Filter.Email),
+		Company:  strings.TrimSpace(opts.Filter.Company),
+		Interest: strings.TrimSpace(opts.Filter.Interest),
+	}
+	if opts.Limit < 0 {
+		opts.Limit = 100
+	}
+	if opts.Offset < 0 {
+		opts.Offset = 0
+	}
+	return opts
+}
+
+func leadListQuery(base string, filter ListFilter, opts ListOptions) (string, []any) {
+	clauses := make([]string, 0, 3)
+	args := make([]any, 0, 5)
+
+	appendLeadFilterClause(&clauses, &args, "email", filter.Email)
+	appendLeadFilterClause(&clauses, &args, "company", filter.Company)
+	appendLeadFilterClause(&clauses, &args, "interest", filter.Interest)
+
+	var builder strings.Builder
+	builder.WriteString(base)
+	if len(clauses) > 0 {
+		builder.WriteString("\nWHERE ")
+		builder.WriteString(strings.Join(clauses, " AND "))
+	}
+	if strings.HasPrefix(base, "\nSELECT") || strings.HasPrefix(base, "SELECT") {
+		builder.WriteString("\nORDER BY id DESC")
+		if opts.Limit > 0 {
+			builder.WriteString("\nLIMIT ? OFFSET ?")
+			args = append(args, opts.Limit, opts.Offset)
+		}
+	}
+
+	return builder.String(), args
+}
+
+func appendLeadFilterClause(clauses *[]string, args *[]any, column, value string) {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return
+	}
+
+	*clauses = append(*clauses, "LOWER(COALESCE("+column+", '')) LIKE ? ESCAPE '\\'")
+	*args = append(*args, likePattern(value))
+}
+
+func likePattern(value string) string {
+	replacer := strings.NewReplacer(`\`, `\\`, `%`, `\%`, `_`, `\_`)
+	return "%" + replacer.Replace(strings.ToLower(strings.TrimSpace(value))) + "%"
 }
 
 func parseSQLiteTime(value string) time.Time {

--- a/internal/leads/repository_test.go
+++ b/internal/leads/repository_test.go
@@ -30,7 +30,7 @@ func TestRepositoryInsert(t *testing.T) {
 		t.Fatalf("insert lead: %v", err)
 	}
 
-	count, err := repo.Count(context.Background())
+	count, err := repo.Count(context.Background(), ListFilter{})
 	if err != nil {
 		t.Fatalf("count leads: %v", err)
 	}
@@ -38,7 +38,7 @@ func TestRepositoryInsert(t *testing.T) {
 		t.Fatalf("count = %d, want 1", count)
 	}
 
-	records, err := repo.List(context.Background(), 10)
+	records, err := repo.List(context.Background(), ListOptions{Limit: 10})
 	if err != nil {
 		t.Fatalf("list leads: %v", err)
 	}
@@ -50,5 +50,74 @@ func TestRepositoryInsert(t *testing.T) {
 	}
 	if records[0].CreatedAt.IsZero() {
 		t.Fatal("created_at was not parsed")
+	}
+}
+
+func TestRepositoryListSupportsFilteringAndPagination(t *testing.T) {
+	db, err := sql.Open("sqlite", ":memory:")
+	if err != nil {
+		t.Fatalf("open sqlite: %v", err)
+	}
+	defer db.Close()
+
+	repo := NewRepository(db)
+	if err := repo.Init(); err != nil {
+		t.Fatalf("init schema: %v", err)
+	}
+
+	for _, lead := range []Lead{
+		{
+			Name:     "Alpha",
+			Company:  "Acme",
+			Email:    "alpha@example.com",
+			Interest: "Provision",
+			Message:  "first",
+		},
+		{
+			Name:     "Beta",
+			Company:  "Acme Labs",
+			Email:    "beta@example.com",
+			Interest: "OTA",
+			Message:  "second",
+		},
+		{
+			Name:     "Gamma",
+			Company:  "Zenith",
+			Email:    "gamma@example.com",
+			Interest: "OTA",
+			Message:  "third",
+		},
+	} {
+		if err := repo.Insert(context.Background(), lead); err != nil {
+			t.Fatalf("insert lead: %v", err)
+		}
+	}
+
+	count, err := repo.Count(context.Background(), ListFilter{
+		Company:  "acme",
+		Interest: "ota",
+	})
+	if err != nil {
+		t.Fatalf("count filtered leads: %v", err)
+	}
+	if count != 1 {
+		t.Fatalf("count = %d, want 1", count)
+	}
+
+	records, err := repo.List(context.Background(), ListOptions{
+		Filter: ListFilter{
+			Interest: "ota",
+		},
+		Limit:  1,
+		Offset: 1,
+	})
+	if err != nil {
+		t.Fatalf("list filtered leads: %v", err)
+	}
+	if len(records) != 1 {
+		t.Fatalf("records = %d, want 1", len(records))
+	}
+	if records[0].Email != "beta@example.com" {
+		t.Fatalf("email = %q, want beta@example.com", records[0].Email)
 	}
 }

--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -20,7 +20,8 @@ import (
 
 type LeadStore interface {
 	Insert(context.Context, leads.Lead) error
-	List(context.Context, int) ([]leads.LeadRecord, error)
+	Count(context.Context, leads.ListFilter) (int, error)
+	List(context.Context, leads.ListOptions) ([]leads.LeadRecord, error)
 }
 
 type Config struct {
@@ -57,6 +58,8 @@ type pageData struct {
 	Leads           []leads.LeadRecord
 	AdminEnabled    bool
 	AdminCSVHref    string
+	LeadFilters     adminLeadFilters
+	LeadPagination  adminLeadPagination
 }
 
 type contactForm struct {
@@ -74,7 +77,28 @@ const (
 	contactEmailMaxLength    = 254
 	contactInterestMaxLength = 120
 	contactMessageMaxLength  = 2000
+	adminLeadPageSize        = 25
 )
+
+type adminLeadFilters struct {
+	Email     string
+	Company   string
+	Interest  string
+	Token     string
+	HasActive bool
+	ClearHref string
+}
+
+type adminLeadPagination struct {
+	Page         int
+	PageSize     int
+	TotalCount   int
+	TotalPages   int
+	Start        int
+	End          int
+	PreviousHref string
+	NextHref     string
+}
 
 func NewServer(cfg Config) (*Server, error) {
 	if cfg.TemplatesDir == "" {
@@ -213,9 +237,27 @@ func (s *Server) handleAdminLeads(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	filters := parseAdminLeadFilters(r)
 	ctx, cancel := context.WithTimeout(r.Context(), 3*time.Second)
 	defer cancel()
-	records, err := s.leadStore.List(ctx, 100)
+
+	totalCount, err := s.leadStore.Count(ctx, filters.listFilter())
+	if err != nil {
+		http.Error(w, "could not load leads", http.StatusInternalServerError)
+		return
+	}
+
+	page := parseAdminLeadPage(r.URL.Query().Get("page"))
+	totalPages := adminLeadTotalPages(totalCount, adminLeadPageSize)
+	if totalPages > 0 && page > totalPages {
+		page = totalPages
+	}
+
+	records, err := s.leadStore.List(ctx, leads.ListOptions{
+		Filter: filters.listFilter(),
+		Limit:  adminLeadPageSize,
+		Offset: (page - 1) * adminLeadPageSize,
+	})
 	if err != nil {
 		http.Error(w, "could not load leads", http.StatusInternalServerError)
 		return
@@ -228,7 +270,10 @@ func (s *Server) handleAdminLeads(w http.ResponseWriter, r *http.Request) {
 	)
 	data.Leads = records
 	data.AdminEnabled = s.adminToken != ""
-	data.AdminCSVHref = s.adminCSVHref(r)
+	data.AdminCSVHref = s.adminCSVHref(filters)
+	data.LeadFilters = filters
+	data.LeadFilters.ClearHref = s.adminLeadsHref(filters.Token, adminLeadFilters{})
+	data.LeadPagination = s.adminLeadPagination(filters, page, totalCount)
 	s.render(w, http.StatusOK, "admin_leads.html", data)
 }
 
@@ -246,9 +291,12 @@ func (s *Server) handleAdminLeadsCSV(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	filters := parseAdminLeadFilters(r)
 	ctx, cancel := context.WithTimeout(r.Context(), 3*time.Second)
 	defer cancel()
-	records, err := s.leadStore.List(ctx, 500)
+	records, err := s.leadStore.List(ctx, leads.ListOptions{
+		Filter: filters.listFilter(),
+	})
 	if err != nil {
 		http.Error(w, "could not load leads", http.StatusInternalServerError)
 		return
@@ -285,12 +333,12 @@ func (s *Server) authorized(r *http.Request) bool {
 	return token == s.adminToken
 }
 
-func (s *Server) adminCSVHref(r *http.Request) string {
-	token := r.URL.Query().Get("token")
-	if token == "" {
+func (s *Server) adminCSVHref(filters adminLeadFilters) string {
+	values := adminLeadQueryValues(filters, 0)
+	if len(values) == 0 {
 		return "/admin/leads.csv"
 	}
-	return "/admin/leads.csv?token=" + url.QueryEscape(token)
+	return "/admin/leads.csv?" + values.Encode()
 }
 
 func (s *Server) unauthorized(w http.ResponseWriter) {
@@ -502,6 +550,100 @@ func formatTime(value time.Time) string {
 func methodNotAllowed(w http.ResponseWriter) {
 	w.Header().Set("Allow", "GET, POST")
 	http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+}
+
+func parseAdminLeadFilters(r *http.Request) adminLeadFilters {
+	email := strings.TrimSpace(r.URL.Query().Get("email"))
+	company := strings.TrimSpace(r.URL.Query().Get("company"))
+	interest := strings.TrimSpace(r.URL.Query().Get("interest"))
+	return adminLeadFilters{
+		Email:     email,
+		Company:   company,
+		Interest:  interest,
+		Token:     strings.TrimSpace(r.URL.Query().Get("token")),
+		HasActive: email != "" || company != "" || interest != "",
+	}
+}
+
+func (filters adminLeadFilters) listFilter() leads.ListFilter {
+	return leads.ListFilter{
+		Email:    filters.Email,
+		Company:  filters.Company,
+		Interest: filters.Interest,
+	}
+}
+
+func parseAdminLeadPage(raw string) int {
+	page, err := strconv.Atoi(strings.TrimSpace(raw))
+	if err != nil || page < 1 {
+		return 1
+	}
+	return page
+}
+
+func adminLeadTotalPages(totalCount, pageSize int) int {
+	if totalCount == 0 || pageSize <= 0 {
+		return 0
+	}
+	return (totalCount + pageSize - 1) / pageSize
+}
+
+func adminLeadQueryValues(filters adminLeadFilters, page int) url.Values {
+	values := url.Values{}
+	if filters.Token != "" {
+		values.Set("token", filters.Token)
+	}
+	if filters.Email != "" {
+		values.Set("email", filters.Email)
+	}
+	if filters.Company != "" {
+		values.Set("company", filters.Company)
+	}
+	if filters.Interest != "" {
+		values.Set("interest", filters.Interest)
+	}
+	if page > 1 {
+		values.Set("page", strconv.Itoa(page))
+	}
+	return values
+}
+
+func (s *Server) adminLeadsHref(token string, filters adminLeadFilters) string {
+	values := adminLeadQueryValues(adminLeadFilters{
+		Email:    filters.Email,
+		Company:  filters.Company,
+		Interest: filters.Interest,
+		Token:    token,
+	}, 0)
+	if len(values) == 0 {
+		return "/admin/leads"
+	}
+	return "/admin/leads?" + values.Encode()
+}
+
+func (s *Server) adminLeadPagination(filters adminLeadFilters, page, totalCount int) adminLeadPagination {
+	pagination := adminLeadPagination{
+		Page:       page,
+		PageSize:   adminLeadPageSize,
+		TotalCount: totalCount,
+		TotalPages: adminLeadTotalPages(totalCount, adminLeadPageSize),
+	}
+	if totalCount == 0 {
+		return pagination
+	}
+
+	pagination.Start = (page-1)*adminLeadPageSize + 1
+	pagination.End = pagination.Start + adminLeadPageSize - 1
+	if pagination.End > totalCount {
+		pagination.End = totalCount
+	}
+	if page > 1 {
+		pagination.PreviousHref = "/admin/leads?" + adminLeadQueryValues(filters, page-1).Encode()
+	}
+	if page < pagination.TotalPages {
+		pagination.NextHref = "/admin/leads?" + adminLeadQueryValues(filters, page+1).Encode()
+	}
+	return pagination
 }
 
 func securityHeaders(next http.Handler) http.Handler {

--- a/internal/web/server_test.go
+++ b/internal/web/server_test.go
@@ -635,3 +635,30 @@ func TestAdminLeadsFiltersAndCSVExportRespectActiveFilters(t *testing.T) {
 		t.Fatalf("csv contains unfiltered leads: %s", csvRec.Body.String())
 	}
 }
+
+func TestAdminLeadsNoMatchEmptyStateMentionsFilters(t *testing.T) {
+	handler := testServerWithAdminToken(t, &memoryLeadStore{leads: []leads.Lead{
+		{
+			Name:     "Alpha",
+			Company:  "Acme",
+			Email:    "alpha@example.com",
+			Interest: "Provision",
+		},
+	}}, "secret")
+
+	req := httptest.NewRequest(http.MethodGet, "/admin/leads?token=secret&email=missing", nil)
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", rec.Code)
+	}
+
+	body := rec.Body.String()
+	if !strings.Contains(body, "No leads match the current filters.") {
+		t.Fatalf("response does not contain filtered empty-state message: %s", body)
+	}
+	if strings.Contains(body, "No leads yet.") {
+		t.Fatalf("response unexpectedly contains generic empty-state message: %s", body)
+	}
+}

--- a/internal/web/server_test.go
+++ b/internal/web/server_test.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -23,9 +24,40 @@ func (s *memoryLeadStore) Insert(_ context.Context, lead leads.Lead) error {
 	return nil
 }
 
-func (s *memoryLeadStore) List(_ context.Context, _ int) ([]leads.LeadRecord, error) {
+func (s *memoryLeadStore) Count(_ context.Context, filter leads.ListFilter) (int, error) {
+	return len(s.filteredRecords(filter)), nil
+}
+
+func (s *memoryLeadStore) List(_ context.Context, opts leads.ListOptions) ([]leads.LeadRecord, error) {
+	records := s.filteredRecords(opts.Filter)
+	if opts.Offset >= len(records) {
+		return []leads.LeadRecord{}, nil
+	}
+	if opts.Offset > 0 {
+		records = records[opts.Offset:]
+	}
+	if opts.Limit > 0 && opts.Limit < len(records) {
+		records = records[:opts.Limit]
+	}
+	return records, nil
+}
+
+func (s *memoryLeadStore) filteredRecords(filter leads.ListFilter) []leads.LeadRecord {
 	records := make([]leads.LeadRecord, 0, len(s.leads))
-	for index, lead := range s.leads {
+	email := strings.ToLower(strings.TrimSpace(filter.Email))
+	company := strings.ToLower(strings.TrimSpace(filter.Company))
+	interest := strings.ToLower(strings.TrimSpace(filter.Interest))
+	for index := len(s.leads) - 1; index >= 0; index-- {
+		lead := s.leads[index]
+		if email != "" && !strings.Contains(strings.ToLower(lead.Email), email) {
+			continue
+		}
+		if company != "" && !strings.Contains(strings.ToLower(lead.Company), company) {
+			continue
+		}
+		if interest != "" && !strings.Contains(strings.ToLower(lead.Interest), interest) {
+			continue
+		}
 		records = append(records, leads.LeadRecord{
 			ID:       int64(index + 1),
 			Name:     lead.Name,
@@ -35,7 +67,7 @@ func (s *memoryLeadStore) List(_ context.Context, _ int) ([]leads.LeadRecord, er
 			Message:  lead.Message,
 		})
 	}
-	return records, nil
+	return records
 }
 
 func testServer(t *testing.T, store LeadStore) http.Handler {
@@ -505,5 +537,101 @@ func TestAdminLeadsCSVWithHeaderToken(t *testing.T) {
 	}
 	if !strings.Contains(rec.Body.String(), "kevin@example.com") {
 		t.Fatalf("csv does not contain lead email: %s", rec.Body.String())
+	}
+}
+
+func TestAdminLeadsSupportsFilteringAndPagination(t *testing.T) {
+	seed := make([]leads.Lead, 0, 27)
+	for index := 1; index <= 27; index++ {
+		seed = append(seed, leads.Lead{
+			Name:     "Lead " + strconv.Itoa(index),
+			Company:  "Company " + strconv.Itoa(index),
+			Email:    "lead-" + strconv.Itoa(index) + "@example.com",
+			Interest: "Provision",
+			Message:  "seed",
+		})
+	}
+	handler := testServerWithAdminToken(t, &memoryLeadStore{leads: seed}, "secret")
+
+	req := httptest.NewRequest(http.MethodGet, "/admin/leads?token=secret&page=2", nil)
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", rec.Code)
+	}
+
+	body := rec.Body.String()
+	if !strings.Contains(body, "Page 2 of 2") {
+		t.Fatalf("response does not contain page summary: %s", body)
+	}
+	if !strings.Contains(body, "Showing 26-27 of 27 leads") {
+		t.Fatalf("response does not contain range summary: %s", body)
+	}
+	if !strings.Contains(body, "lead-2@example.com") {
+		t.Fatalf("response does not contain second page lead: %s", body)
+	}
+	if strings.Contains(body, "lead-27@example.com") {
+		t.Fatalf("response unexpectedly contains first page lead: %s", body)
+	}
+	if !strings.Contains(body, "/admin/leads?token=secret") {
+		t.Fatalf("response does not contain previous-page link: %s", body)
+	}
+}
+
+func TestAdminLeadsFiltersAndCSVExportRespectActiveFilters(t *testing.T) {
+	store := &memoryLeadStore{leads: []leads.Lead{
+		{
+			Name:     "Alpha",
+			Company:  "Acme",
+			Email:    "alpha@example.com",
+			Interest: "Provision",
+		},
+		{
+			Name:     "Beta",
+			Company:  "Acme Labs",
+			Email:    "beta@example.com",
+			Interest: "OTA",
+		},
+		{
+			Name:     "Gamma",
+			Company:  "Zenith",
+			Email:    "gamma@example.com",
+			Interest: "OTA",
+		},
+	}}
+	handler := testServerWithAdminToken(t, store, "secret")
+
+	req := httptest.NewRequest(http.MethodGet, "/admin/leads?token=secret&email=beta&company=acme&interest=ota", nil)
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", rec.Code)
+	}
+
+	body := rec.Body.String()
+	if !strings.Contains(body, "beta@example.com") {
+		t.Fatalf("response does not contain filtered lead: %s", body)
+	}
+	if strings.Contains(body, "alpha@example.com") || strings.Contains(body, "gamma@example.com") {
+		t.Fatalf("response contains unfiltered leads: %s", body)
+	}
+	if !strings.Contains(body, "/admin/leads.csv?company=acme&amp;email=beta&amp;interest=ota&amp;token=secret") {
+		t.Fatalf("response does not preserve filters in csv link: %s", body)
+	}
+
+	csvReq := httptest.NewRequest(http.MethodGet, "/admin/leads.csv?token=secret&email=beta&company=acme&interest=ota", nil)
+	csvRec := httptest.NewRecorder()
+	handler.ServeHTTP(csvRec, csvReq)
+
+	if csvRec.Code != http.StatusOK {
+		t.Fatalf("csv status = %d, want 200", csvRec.Code)
+	}
+	if !strings.Contains(csvRec.Body.String(), "beta@example.com") {
+		t.Fatalf("csv does not contain filtered lead: %s", csvRec.Body.String())
+	}
+	if strings.Contains(csvRec.Body.String(), "alpha@example.com") || strings.Contains(csvRec.Body.String(), "gamma@example.com") {
+		t.Fatalf("csv contains unfiltered leads: %s", csvRec.Body.String())
 	}
 }

--- a/static/styles.css
+++ b/static/styles.css
@@ -538,6 +538,40 @@ textarea:focus {
   padding-top: 18px;
 }
 
+.admin-filters {
+  display: grid;
+  gap: 16px;
+  margin-bottom: 18px;
+  padding: 18px;
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  background: #fff;
+}
+
+.filter-grid {
+  display: grid;
+  gap: 14px;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+}
+
+.filter-grid label,
+.filter-actions,
+.admin-summary {
+  display: grid;
+  gap: 8px;
+}
+
+.filter-grid span {
+  color: var(--navy);
+  font-size: 0.84rem;
+  font-weight: 700;
+}
+
+.filter-actions {
+  grid-auto-flow: column;
+  justify-content: flex-start;
+}
+
 .admin-actions {
   display: flex;
   align-items: center;
@@ -548,6 +582,11 @@ textarea:focus {
   border: 1px solid var(--line);
   border-radius: 8px;
   background: var(--bg-soft);
+}
+
+.admin-summary p,
+.admin-actions p {
+  margin: 0;
 }
 
 code {
@@ -602,6 +641,20 @@ td a {
   background: #fff;
 }
 
+.admin-pagination {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  margin-top: 18px;
+}
+
+.admin-pagination p {
+  margin: 0;
+  color: var(--navy);
+  font-weight: 700;
+}
+
 .success-message {
   display: grid;
   gap: 16px;
@@ -646,7 +699,8 @@ td a {
   .feature-grid,
   .docs-entry-grid,
   .use-case-list,
-  .detail-grid {
+  .detail-grid,
+  .filter-grid {
     grid-template-columns: repeat(2, minmax(0, 1fr));
   }
 
@@ -664,9 +718,14 @@ td a {
 
   .cta-band,
   .site-footer,
-  .admin-actions {
+  .admin-actions,
+  .admin-pagination {
     align-items: flex-start;
     flex-direction: column;
+  }
+
+  .filter-actions {
+    grid-auto-flow: row;
   }
 }
 
@@ -694,7 +753,8 @@ td a {
   .feature-grid,
   .docs-entry-grid,
   .use-case-list,
-  .detail-grid {
+  .detail-grid,
+  .filter-grid {
     grid-template-columns: 1fr;
   }
 

--- a/templates/admin_leads.html
+++ b/templates/admin_leads.html
@@ -6,7 +6,43 @@
 </section>
 
 <section class="section admin-section">
+  <form class="admin-filters" method="get" action="/admin/leads">
+    {{if .LeadFilters.Token}}
+    <input type="hidden" name="token" value="{{.LeadFilters.Token}}">
+    {{end}}
+    <div class="filter-grid">
+      <label>
+        <span>Email</span>
+        <input type="search" name="email" value="{{.LeadFilters.Email}}" placeholder="Search by email">
+      </label>
+      <label>
+        <span>Company</span>
+        <input type="search" name="company" value="{{.LeadFilters.Company}}" placeholder="Search by company">
+      </label>
+      <label>
+        <span>Interest</span>
+        <input type="search" name="interest" value="{{.LeadFilters.Interest}}" placeholder="Search by interest">
+      </label>
+    </div>
+    <div class="filter-actions">
+      <button class="button" type="submit">Apply filters</button>
+      {{if .LeadFilters.HasActive}}
+      <a class="button secondary" href="{{.LeadFilters.ClearHref}}">Clear filters</a>
+      {{end}}
+    </div>
+  </form>
+
   <div class="admin-actions">
+    <div class="admin-summary">
+      {{if .LeadPagination.TotalCount}}
+      <p>Showing {{.LeadPagination.Start}}-{{.LeadPagination.End}} of {{.LeadPagination.TotalCount}} leads.</p>
+      <p>Page {{.LeadPagination.Page}} of {{.LeadPagination.TotalPages}}.</p>
+      {{else if .LeadFilters.HasActive}}
+      <p>No leads match the current filters.</p>
+      {{else}}
+      <p>No leads have been captured yet.</p>
+      {{end}}
+    </div>
     <a class="button secondary" href="{{.AdminCSVHref}}">Export CSV</a>
     <p>CSV export requires the same <code>X-Admin-Token</code> header, or a <code>?token=...</code> query parameter when using a browser.</p>
   </div>
@@ -40,6 +76,17 @@
       </tbody>
     </table>
   </div>
+  {{if gt .LeadPagination.TotalPages 1}}
+  <div class="admin-pagination">
+    {{if .LeadPagination.PreviousHref}}
+    <a class="button secondary" href="{{.LeadPagination.PreviousHref}}">Previous</a>
+    {{end}}
+    <p>Page {{.LeadPagination.Page}} of {{.LeadPagination.TotalPages}}</p>
+    {{if .LeadPagination.NextHref}}
+    <a class="button secondary" href="{{.LeadPagination.NextHref}}">Next</a>
+    {{end}}
+  </div>
+  {{end}}
   {{else}}
   <div class="empty-state">
     <h2>No leads yet.</h2>

--- a/templates/admin_leads.html
+++ b/templates/admin_leads.html
@@ -89,8 +89,13 @@
   {{end}}
   {{else}}
   <div class="empty-state">
+    {{if .LeadFilters.HasActive}}
+    <h2>No leads match the current filters.</h2>
+    <p>Adjust the admin search filters or clear them to view all captured leads.</p>
+    {{else}}
     <h2>No leads yet.</h2>
     <p>Submitted contact requests will appear here after the form writes to SQLite.</p>
+    {{end}}
   </div>
   {{end}}
 </section>


### PR DESCRIPTION
Refs #14

## Summary
- add server-side admin lead filtering by email, company, and interest with paginated results
- make protected CSV export respect the active admin filters
- extend admin UI and repository coverage for filtered queries, paging, and filtered export behavior

## Validation
- go test ./...
- go build ./cmd/server
