### PR TITLE
Improve accessibility and responsive UX

### DIFF
--- a/internal/web/server_test.go
+++ b/internal/web/server_test.go
@@ -142,6 +142,28 @@ func TestHomeMetadataIncludesSocialTags(t *testing.T) {
 	}
 }
 
+func TestLayoutIncludesSkipLinkToMainContent(t *testing.T) {
+	handler := testServer(t, &memoryLeadStore{})
+
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", rec.Code)
+	}
+
+	body := rec.Body.String()
+	for _, want := range []string{
+		`<a class="skip-link" href="#main-content">Skip to main content</a>`,
+		`<main id="main-content" tabindex="-1">`,
+	} {
+		if !strings.Contains(body, want) {
+			t.Fatalf("response does not contain %q: %s", want, body)
+		}
+	}
+}
+
 func TestFeatureMetadataUsesFeatureSummary(t *testing.T) {
 	handler := testServer(t, &memoryLeadStore{})
 
@@ -299,6 +321,48 @@ func TestInvalidContactPostDoesNotStoreLead(t *testing.T) {
 	}
 	if !strings.Contains(rec.Body.String(), "Name is required") {
 		t.Fatalf("response does not contain validation error: %s", rec.Body.String())
+	}
+}
+
+func TestInvalidContactPostUsesAccessibleErrorMarkup(t *testing.T) {
+	store := &memoryLeadStore{}
+	handler := testServer(t, store)
+
+	form := url.Values{
+		"name":     {""},
+		"company":  {"Realtek"},
+		"email":    {"not-an-email"},
+		"interest": {""},
+	}
+	req := httptest.NewRequest(http.MethodPost, "/contact", strings.NewReader(form.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	rec := httptest.NewRecorder()
+
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400", rec.Code)
+	}
+
+	body := rec.Body.String()
+	for _, want := range []string{
+		`<div class="form-error-summary" role="alert" aria-labelledby="contact-errors-title" tabindex="-1">`,
+		`<a href="#contact-name">Name is required.</a>`,
+		`<a href="#contact-email">Enter a valid email address.</a>`,
+		`<a href="#contact-interest">Select an area of interest.</a>`,
+		`id="contact-name"`,
+		`aria-describedby="contact-name-error"`,
+		`id="contact-email"`,
+		`aria-describedby="contact-email-error"`,
+		`id="contact-interest"`,
+		`aria-describedby="contact-interest-error"`,
+	} {
+		if !strings.Contains(body, want) {
+			t.Fatalf("response does not contain %q: %s", want, body)
+		}
+	}
+	if strings.Count(body, `aria-invalid="true"`) != 3 {
+		t.Fatalf("response should flag three invalid fields: %s", body)
 	}
 }
 

--- a/static/styles.css
+++ b/static/styles.css
@@ -3,11 +3,11 @@
   --bg-soft: #f4f8fa;
   --bg-panel: #eef6f7;
   --text: #122333;
-  --muted: #5f7180;
+  --muted: #445665;
   --line: #d7e5e8;
-  --brand: #008c95;
-  --brand-dark: #006e77;
-  --brand-soft: #dff5f6;
+  --brand: #006f78;
+  --brand-dark: #00565d;
+  --brand-soft: #d8eef0;
   --navy: #102a43;
   --shadow: 0 18px 44px rgba(16, 42, 67, 0.08);
 }
@@ -31,6 +31,23 @@ body {
 a {
   color: inherit;
   text-decoration: none;
+}
+
+.skip-link {
+  position: absolute;
+  top: 16px;
+  left: 20px;
+  z-index: 20;
+  padding: 10px 14px;
+  border-radius: 8px;
+  background: var(--navy);
+  color: #fff;
+  transform: translateY(-140%);
+  transition: transform 140ms ease;
+}
+
+.skip-link:focus-visible {
+  transform: translateY(0);
 }
 
 img {
@@ -80,6 +97,7 @@ img {
 .main-nav {
   display: flex;
   align-items: center;
+  flex-wrap: wrap;
   gap: clamp(14px, 3vw, 30px);
   color: var(--muted);
   font-size: 0.95rem;
@@ -187,6 +205,11 @@ p {
   border: 1px solid transparent;
   font-weight: 760;
   line-height: 1;
+}
+
+:where(a, button, input, select, textarea, [tabindex="-1"]):focus-visible {
+  outline: 3px solid rgba(0, 111, 120, 0.22);
+  outline-offset: 3px;
 }
 
 .button.primary {
@@ -482,11 +505,24 @@ form {
   gap: 16px;
 }
 
+.form-field {
+  display: grid;
+  gap: 7px;
+}
+
 label {
   display: grid;
   gap: 7px;
   color: var(--navy);
   font-weight: 720;
+}
+
+.form-field label {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 6px 12px;
+  line-height: 1.4;
 }
 
 label em {
@@ -496,7 +532,7 @@ label em {
   font-weight: 650;
 }
 
-.form-error {
+.form-error-summary {
   margin: 0;
   padding: 12px 14px;
   border: 1px solid rgba(180, 35, 24, 0.2);
@@ -505,6 +541,23 @@ label em {
   color: #b42318;
   font-size: 0.95rem;
   font-weight: 650;
+}
+
+.form-error-summary p,
+.form-error-summary ul {
+  margin: 0;
+}
+
+.form-error-summary ul {
+  display: grid;
+  gap: 8px;
+  margin-top: 10px;
+  padding-left: 20px;
+}
+
+.form-error-summary a {
+  color: var(--brand-dark);
+  text-decoration: underline;
 }
 
 .honeypot-field {
@@ -527,11 +580,18 @@ textarea {
   font: inherit;
 }
 
-input:focus,
-select:focus,
-textarea:focus {
-  outline: 3px solid rgba(0, 140, 149, 0.18);
+input:focus-visible,
+select:focus-visible,
+textarea:focus-visible {
   border-color: var(--brand);
+  box-shadow: 0 0 0 4px rgba(0, 111, 120, 0.14);
+}
+
+input[aria-invalid="true"],
+select[aria-invalid="true"],
+textarea[aria-invalid="true"] {
+  border-color: #b42318;
+  background: #fff7f7;
 }
 
 .admin-section {
@@ -732,8 +792,8 @@ td a {
 @media (max-width: 620px) {
   .main-nav {
     width: 100%;
-    justify-content: space-between;
-    gap: 10px;
+    justify-content: flex-start;
+    gap: 10px 16px;
     font-size: 0.9rem;
   }
 
@@ -756,6 +816,15 @@ td a {
   .detail-grid,
   .filter-grid {
     grid-template-columns: 1fr;
+  }
+
+  .page-hero.compact {
+    margin-left: auto;
+  }
+
+  .form-field label {
+    align-items: flex-start;
+    flex-direction: column;
   }
 
   .feature-card,

--- a/templates/contact.html
+++ b/templates/contact.html
@@ -1,4 +1,10 @@
 {{define "content"}}
+{{$formError := index .Errors "form"}}
+{{$nameError := index .Errors "name"}}
+{{$companyError := index .Errors "company"}}
+{{$emailError := index .Errors "email"}}
+{{$interestError := index .Errors "interest"}}
+{{$messageError := index .Errors "message"}}
 <section class="page-hero compact">
   <p class="eyebrow">Contact</p>
   <h1>Register interest in Realtek Connect+.</h1>
@@ -21,41 +27,63 @@
     </div>
     {{else}}
     <form method="post" action="/contact" novalidate>
-      {{with index .Errors "form"}}<p class="form-error" role="alert">{{.}}</p>{{end}}
+      {{if .Errors}}
+      <div class="form-error-summary" role="alert" aria-labelledby="contact-errors-title" tabindex="-1">
+        <p id="contact-errors-title">Please review the details below before submitting.</p>
+        <ul>
+          {{with $formError}}<li>{{.}}</li>{{end}}
+          {{with $nameError}}<li><a href="#contact-name">{{.}}</a></li>{{end}}
+          {{with $companyError}}<li><a href="#contact-company">{{.}}</a></li>{{end}}
+          {{with $emailError}}<li><a href="#contact-email">{{.}}</a></li>{{end}}
+          {{with $interestError}}<li><a href="#contact-interest">{{.}}</a></li>{{end}}
+          {{with $messageError}}<li><a href="#contact-message">{{.}}</a></li>{{end}}
+        </ul>
+      </div>
+      {{end}}
       <div class="honeypot-field" aria-hidden="true">
         <label for="contact-website">Website</label>
         <input id="contact-website" name="website" type="text" tabindex="-1" autocomplete="off">
       </div>
-      <label>
-        <span>Name</span>
-        {{with index .Errors "name"}}<em>{{.}}</em>{{end}}
-        <input name="name" value="{{.Form.Name}}" autocomplete="name" maxlength="120" required>
-      </label>
-      <label>
-        <span>Company</span>
-        {{with index .Errors "company"}}<em>{{.}}</em>{{end}}
-        <input name="company" value="{{.Form.Company}}" autocomplete="organization" maxlength="160">
-      </label>
-      <label>
-        <span>Email</span>
-        {{with index .Errors "email"}}<em>{{.}}</em>{{end}}
-        <input name="email" value="{{.Form.Email}}" type="email" autocomplete="email" maxlength="254" required>
-      </label>
-      <label>
-        <span>Interest</span>
-        {{with index .Errors "interest"}}<em>{{.}}</em>{{end}}
-        <select name="interest" required>
+      <div class="form-field">
+        <label for="contact-name">
+          <span>Name</span>
+          {{with $nameError}}<em id="contact-name-error">{{.}}</em>{{end}}
+        </label>
+        <input id="contact-name" name="name" value="{{.Form.Name}}" autocomplete="name" maxlength="120" required {{if $nameError}}aria-invalid="true" aria-describedby="contact-name-error"{{end}}>
+      </div>
+      <div class="form-field">
+        <label for="contact-company">
+          <span>Company</span>
+          {{with $companyError}}<em id="contact-company-error">{{.}}</em>{{end}}
+        </label>
+        <input id="contact-company" name="company" value="{{.Form.Company}}" autocomplete="organization" maxlength="160" {{if $companyError}}aria-invalid="true" aria-describedby="contact-company-error"{{end}}>
+      </div>
+      <div class="form-field">
+        <label for="contact-email">
+          <span>Email</span>
+          {{with $emailError}}<em id="contact-email-error">{{.}}</em>{{end}}
+        </label>
+        <input id="contact-email" name="email" value="{{.Form.Email}}" type="email" autocomplete="email" maxlength="254" required {{if $emailError}}aria-invalid="true" aria-describedby="contact-email-error"{{end}}>
+      </div>
+      <div class="form-field">
+        <label for="contact-interest">
+          <span>Interest</span>
+          {{with $interestError}}<em id="contact-interest-error">{{.}}</em>{{end}}
+        </label>
+        <select id="contact-interest" name="interest" required {{if $interestError}}aria-invalid="true" aria-describedby="contact-interest-error"{{end}}>
           <option value="">Select a service</option>
           {{range .Features}}
           <option value="{{.Title}}" {{if eq $.Form.Interest .Title}}selected{{end}}>{{.Title}}</option>
           {{end}}
         </select>
-      </label>
-      <label>
-        <span>Message</span>
-        {{with index .Errors "message"}}<em>{{.}}</em>{{end}}
-        <textarea name="message" rows="5" maxlength="2000">{{.Form.Message}}</textarea>
-      </label>
+      </div>
+      <div class="form-field">
+        <label for="contact-message">
+          <span>Message</span>
+          {{with $messageError}}<em id="contact-message-error">{{.}}</em>{{end}}
+        </label>
+        <textarea id="contact-message" name="message" rows="5" maxlength="2000" {{if $messageError}}aria-invalid="true" aria-describedby="contact-message-error"{{end}}>{{.Form.Message}}</textarea>
+      </div>
       <button class="button primary" type="submit">Submit Request</button>
     </form>
     {{end}}

--- a/templates/layout.html
+++ b/templates/layout.html
@@ -23,6 +23,7 @@
   <link rel="stylesheet" href="/static/styles.css">
 </head>
 <body>
+  <a class="skip-link" href="#main-content">Skip to main content</a>
   <header class="site-header">
     <a class="brand" href="/" aria-label="Realtek Connect+ home">
       <span class="brand-mark">Realtek</span>
@@ -37,7 +38,7 @@
     </nav>
   </header>
 
-  <main>
+  <main id="main-content" tabindex="-1">
     {{template "content" .}}
   </main>
 


### PR DESCRIPTION
Refs #12

## Summary
- add a keyboard-accessible skip link and visible focus treatments across the shared layout and form controls
- restructure the contact form so validation errors are summarized and explicitly associated with each invalid field
- tighten the public color tokens and small-screen navigation/layout rules to keep mobile pages within the viewport without horizontal overflow

## Validation
- `go test ./internal/web`
- `go build ./cmd/server`
- `go test ./...`
- browser DOM-width checks on `http://127.0.0.1:38888/` at desktop `1440px` and mobile `390px`
- browser DOM-width checks on `http://127.0.0.1:38888/contact` at mobile `390px`
