### PR TITLE
Add user management feature content

### DIFF
--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -19,7 +19,7 @@ Implemented today:
 - Generated hero/platform image stored in `static/assets/connectplus-hero.png`.
 - Per-page title, description, canonical, Open Graph, and Twitter card metadata.
 - Developer docs landing and detail pages covering Product Overview, Development, APIs, SDKs, Firmware, CLI, Deployment, and Release Notes.
-- Feature overview and detail pages for Provision, OTA, Fleet Management, App SDK, Insights, Private Cloud, and Integrations.
+- Feature overview and detail pages for Provision, OTA, Fleet Management, User Management, App SDK, Insights, Private Cloud, and Integrations.
 - `robots.txt` and `sitemap.xml` routes for crawl and link discovery.
 - Contact / early access registration form.
 - SQLite lead capture through `DATABASE_PATH`, defaulting to `data/connectplus.db`.
@@ -77,6 +77,7 @@ Realtek Connect+ presents the following ESP RainMaker-aligned capabilities:
 - Provision: Wi-Fi/BLE onboarding, device binding, activation, user-device association.
 - OTA: firmware upload, campaign rollout, job status, cancel/archive, version validation, and Immediate/Scheduled/User-controlled rollout modes.
 - Fleet Management: device registry, groups, metadata/tags, batch operations, timezone, device sharing.
+- User Management: sign up, sign in, OTP verification, third-party login, password recovery/change, and account deletion framed as platform capabilities rather than current website authentication flows.
 - App SDK: iOS/Android SDK, sample app, rebrand/customize path, push notifications, app publishing path.
 - Insights: activation statistics, firmware distribution, logs, crash reports, reboot reasons, RSSI/memory metrics.
 - Private Cloud: enterprise deployment, data ownership, custom domain, cloud customization, commercial support.
@@ -97,7 +98,7 @@ Status values:
 | Provision | Content Partial | Add QR code, SoftAP/BLE flow, device claiming, activation, user-node association, local setup failure states, and product onboarding diagrams. |
 | OTA | Content Partial | Add firmware upload, metadata extraction, model/version targeting, force/normal/user-controlled/time-window OTA, dynamic OTA, job detail, cancel/archive, and rollout strategy visuals. |
 | Fleet Management / Admin Operations | Content Partial | Add node registration, certificate flow, device registry, groups, metadata, batch operations, node summary widgets, activation statistics, and admin console concept. |
-| User Management | Planned | Add content for sign up, sign in, OTP verification, third-party login, forgot/change password, account deletion, session behavior, and user lifecycle. |
+| User Management | Content Partial | Feature content now covers sign up, sign in, OTP verification, third-party login, forgot/change password, account deletion, and account lifecycle boundaries; follow-on work can add deeper support models, session behavior, and visual diagrams. |
 | End-user Smart Home Features | Planned | Add remote control, local control, scheduling, scenes, grouping, node sharing, push notifications, alerts, and mobile user workflows. |
 | Mobile App SDK | Content Partial | Add iOS SDK, Android SDK, sample app, customization/rebrand, push notification, app store publishing, widgets/settings, and app developer roadmap. |
 | Insights | Content Partial | Add logs, crash reports, reboot reasons, custom metrics, RSSI/memory metrics, firmware distribution, support workflows, and dashboard visuals. |
@@ -137,6 +138,7 @@ Feature slugs:
 - `provision`
 - `ota`
 - `fleet-management`
+- `user-management`
 - `app-sdk`
 - `insights`
 - `private-cloud`

--- a/internal/features/features.go
+++ b/internal/features/features.go
@@ -44,6 +44,16 @@ func All() []Feature {
 			Outcomes:     []string{"Keep fleets searchable", "Support commercial support workflows", "Scale operations beyond launch"},
 		},
 		{
+			Slug:         "user-management",
+			Title:        "User Management",
+			Kicker:       "Handle the account lifecycle around connected products.",
+			Summary:      "Platform content for sign up, sign in, OTP verification, social login, password recovery, account changes, and account deletion.",
+			Description:  "User Management describes the account lifecycle capabilities product teams usually need around a Realtek-based connected product. It covers identity onboarding, recovery, and privacy operations for future product apps and services. This website does not expose end-user sign-in or account management flows today.",
+			Highlights:   []string{"Self-service sign up and sign in journeys for branded mobile apps", "One-time password verification for account activation, recovery, and high-risk actions", "Third-party login and account-linking paths for partner or consumer ecosystems"},
+			Capabilities: []string{"Forgot-password, change-password, and session-management controls", "Account deletion and retention workflows that hand off cleanly to support and compliance teams", "User profile, consent, and device-ownership state that stays separate from this marketing website"},
+			Outcomes:     []string{"Shorten time to a production-ready account system", "Keep user lifecycle scope explicit during architecture reviews", "Avoid confusing product platform capabilities with the website's own lead-capture flows"},
+		},
+		{
 			Slug:         "app-sdk",
 			Title:        "App SDK",
 			Kicker:       "Build branded mobile experiences faster.",

--- a/internal/web/server_test.go
+++ b/internal/web/server_test.go
@@ -166,6 +166,33 @@ func TestFeatureMetadataUsesFeatureSummary(t *testing.T) {
 	}
 }
 
+func TestUserManagementFeatureClarifiesPlatformScope(t *testing.T) {
+	handler := testServer(t, &memoryLeadStore{})
+
+	req := httptest.NewRequest(http.MethodGet, "/features/user-management", nil)
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", rec.Code)
+	}
+
+	body := rec.Body.String()
+	for _, want := range []string{
+		"User Management",
+		"sign up and sign in",
+		"One-time password verification",
+		"Third-party login and account-linking paths",
+		"Forgot-password, change-password, and session-management controls",
+		"Account deletion and retention workflows",
+		"This website does not expose end-user sign-in or account management flows today.",
+	} {
+		if !strings.Contains(body, want) {
+			t.Fatalf("response does not contain %q: %s", want, body)
+		}
+	}
+}
+
 func TestRobotsTxtIncludesSitemap(t *testing.T) {
 	handler := testServer(t, &memoryLeadStore{})
 


### PR DESCRIPTION
Refs #3

## Summary
- add a new server-rendered `user-management` feature page to cover account lifecycle capabilities
- make the copy explicit that sign-up, sign-in, OTP, social login, password flows, and account deletion are platform capabilities rather than current website auth flows
- update the spec parity matrix and add a regression test for the new feature route content

## Validation
- `go test ./internal/web`
- `go test ./...`
- `go build ./cmd/server`
