### PR TITLE
Expand OTA feature detail

### DIFF
--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -19,7 +19,7 @@ Implemented today:
 - Generated hero/platform image stored in `static/assets/connectplus-hero.png`.
 - Per-page title, description, canonical, Open Graph, and Twitter card metadata.
 - Developer docs landing and detail pages covering Product Overview, Development, APIs, SDKs, Firmware, CLI, Deployment, and Release Notes.
-- Feature overview and detail pages for Provision, OTA, Fleet Management, App SDK, Insights, Private Cloud, and Integrations.
+- Feature overview and detail pages for Provision, OTA, Fleet Management, App SDK, Insights, Private Cloud, and Integrations, including production-grade OTA rollout detail.
 - `robots.txt` and `sitemap.xml` routes for crawl and link discovery.
 - Contact / early access registration form.
 - SQLite lead capture through `DATABASE_PATH`, defaulting to `data/connectplus.db`.
@@ -95,7 +95,7 @@ Status values:
 | --- | --- | --- |
 | Platform Overview | Content Partial | Add stronger end-to-end architecture story, developer entry points, security/scalability/cost positioning, and deployment model comparison. |
 | Provision | Content Partial | Add QR code, SoftAP/BLE flow, device claiming, activation, user-node association, local setup failure states, and product onboarding diagrams. |
-| OTA | Content Partial | Add firmware upload, metadata extraction, model/version targeting, force/normal/user-controlled/time-window OTA, dynamic OTA, job detail, cancel/archive, and rollout strategy visuals. |
+| OTA | Implemented | `/features/ota` now covers firmware upload, extracted release metadata, model/version targeting, immediate/scheduled/user-controlled/time-window rollouts, dynamic OTA eligibility, job detail, cancellation, archive flow, and a structured rollout strategy table. |
 | Fleet Management / Admin Operations | Content Partial | Add node registration, certificate flow, device registry, groups, metadata, batch operations, node summary widgets, activation statistics, and admin console concept. |
 | User Management | Planned | Add content for sign up, sign in, OTP verification, third-party login, forgot/change password, account deletion, session behavior, and user lifecycle. |
 | End-user Smart Home Features | Planned | Add remote control, local control, scheduling, scenes, grouping, node sharing, push notifications, alerts, and mobile user workflows. |
@@ -110,7 +110,7 @@ Status values:
 ## Website Completion Roadmap
 
 - **v0.1 Marketing Foundation**: current state. Working Go site, product positioning, core feature pages, generated hero asset, contact lead capture, admin lead export.
-- **v0.2 RainMaker Parity Content**: expand content depth so Realtek Connect+ can credibly map to ESP RainMaker's feature set across user, admin, mobile SDK, deployment, Matter, and developer documentation areas.
+- **v0.2 RainMaker Parity Content**: expand remaining content depth so Realtek Connect+ can credibly map to ESP RainMaker's feature set across user, admin, mobile SDK, deployment, Matter, and developer documentation areas.
 - **v0.3 Launch Readiness**: improve SEO, accessibility, visual assets, deployment packaging, CI, form hardening, admin usability, and server operations.
 - **v1.0 Public Website Candidate**: polished public-facing site with complete parity content, Realtek brand assets, reliable contact/admin workflows, and deployment documentation.
 

--- a/internal/features/features.go
+++ b/internal/features/features.go
@@ -9,6 +9,28 @@ type Feature struct {
 	Highlights   []string
 	Capabilities []string
 	Outcomes     []string
+	Sections     []FeatureSection
+	Table        FeatureTable
+}
+
+type FeatureSection struct {
+	Eyebrow string
+	Title   string
+	Intro   string
+	Items   []string
+	Accent  bool
+}
+
+type FeatureTable struct {
+	Eyebrow string
+	Title   string
+	Intro   string
+	Columns []string
+	Rows    []FeatureTableRow
+}
+
+type FeatureTableRow struct {
+	Cells []string
 }
 
 func All() []Feature {
@@ -27,11 +49,56 @@ func All() []Feature {
 			Slug:         "ota",
 			Title:        "OTA",
 			Kicker:       "Ship firmware updates with rollout control.",
-			Summary:      "Upload firmware, create rollout campaigns, monitor jobs, and protect devices with version validation.",
-			Description:  "OTA is presented as a full firmware lifecycle service: binaries are registered, campaigns are targeted to devices or groups, jobs can be monitored or cancelled, and firmware-side checks help prevent incorrect images from being applied.",
-			Highlights:   []string{"Immediate, scheduled, and user-controlled rollout modes", "Campaign status tracking and archive flow", "Project and version validation on device"},
-			Capabilities: []string{"Firmware binary registration", "Targeting by group, model, or firmware version", "Job progress, cancellation, and history"},
-			Outcomes:     []string{"Lower maintenance cost", "Safer staged rollouts", "Recover faster from firmware issues"},
+			Summary:      "Upload firmware, extract release metadata, target staged rollouts, and monitor dynamic OTA jobs with policy-level safeguards.",
+			Description:  "OTA is positioned as a production firmware operations surface rather than a simple update button. Teams register firmware packages, review extracted version and model metadata, define rollout policies, and watch job progress from pilot cohorts through archive-ready release history.",
+			Highlights:   []string{"Firmware upload pipeline with extracted version, model, and release metadata", "Version, model, region, and cohort targeting for staged campaigns", "Immediate, scheduled, user-controlled, and time-window rollout modes"},
+			Capabilities: []string{"Dynamic OTA policies for always-on or intermittently connected fleets", "Per-job status, device outcomes, cancellation, and archive history", "Compatibility validation and operator approvals before rollout"},
+			Outcomes:     []string{"Lower firmware support cost", "Reduce fleet-wide regression risk", "Coordinate releases across consumer and commercial deployments"},
+			Sections: []FeatureSection{
+				{
+					Eyebrow: "Workflow",
+					Title:   "From signed image upload to job execution",
+					Intro:   "The OTA page now describes the full release workflow product teams expect before a binary reaches devices.",
+					Items: []string{
+						"Upload signed firmware images and extract embedded project, version, model, checksum, and release-note metadata.",
+						"Attach rollout notes, mandatory or optional install policy, and maintenance-window guidance before approval.",
+						"Create job detail views that show pending, in-progress, succeeded, cancelled, and failed device outcomes by campaign wave.",
+					},
+				},
+				{
+					Eyebrow: "Targeting",
+					Title:   "Match each rollout to the right fleet slice",
+					Intro:   "Campaign definition is described as an operator workflow rather than a live cloud implementation promise.",
+					Items: []string{
+						"Target by product family, hardware model, current firmware version, customer tier, region, or support cohort.",
+						"Blend pilot cohorts with staged expansion so operators can start narrow, inspect telemetry, and widen safely.",
+						"Use dynamic OTA rules to keep offline devices eligible for the latest approved package when they reconnect.",
+					},
+				},
+				{
+					Eyebrow: "Controls",
+					Title:   "Safety checks and release operations",
+					Intro:   "Operational controls stay explicit about website scope while still showing a credible release-management story.",
+					Items: []string{
+						"Validate project and version compatibility before devices accept a package.",
+						"Cancel active waves and archive completed campaigns without losing audit history.",
+						"Retain operator-visible status, retry intent, and exception handling notes for support and QA teams.",
+					},
+					Accent: true,
+				},
+			},
+			Table: FeatureTable{
+				Eyebrow: "Rollout Strategies",
+				Title:   "Choose the delivery mode that fits the release",
+				Intro:   "Realtek Connect+ describes rollout modes as policy templates. Dynamic OTA keeps device eligibility aligned with the latest approved campaign even when endpoints reconnect later.",
+				Columns: []string{"Strategy", "Operator control", "Targeting pattern", "Best fit"},
+				Rows: []FeatureTableRow{
+					{Cells: []string{"Immediate", "Launch now and monitor wave status in real time.", "Urgent hotfixes across a narrow pilot or the whole eligible fleet.", "Critical security patches or rapid rollback replacements."}},
+					{Cells: []string{"Scheduled", "Approve once, then release during a defined maintenance window.", "Region- or customer-specific batches timed for low-support hours.", "Planned feature releases and coordinated commercial deployments."}},
+					{Cells: []string{"User-controlled", "Notify users, keep the job pending, and let the app or device owner choose install timing.", "Consumer devices that must respect end-user availability and local context.", "Appliances and smart-home products where UX matters more than immediacy."}},
+					{Cells: []string{"Time-window", "Allow installs only inside approved hours while preserving campaign eligibility outside the window.", "Always-on fleets, retail estates, or shared environments with operational blackout periods.", "Commercial fleets that need policy-driven upgrades without overnight surprises."}},
+				},
+			},
 		},
 		{
 			Slug:         "fleet-management",

--- a/internal/web/server_test.go
+++ b/internal/web/server_test.go
@@ -178,9 +178,37 @@ func TestFeatureMetadataUsesFeatureSummary(t *testing.T) {
 	body := rec.Body.String()
 	for _, want := range []string{
 		`<title>OTA | Realtek Connect&#43;</title>`,
-		`<meta name="description" content="Upload firmware, create rollout campaigns, monitor jobs, and protect devices with version validation.">`,
+		`<meta name="description" content="Upload firmware, extract release metadata, target staged rollouts, and monitor dynamic OTA jobs with policy-level safeguards.">`,
 		`<meta property="og:url" content="http://example.com/features/ota">`,
 		`<meta name="twitter:title" content="OTA | Realtek Connect&#43;">`,
+	} {
+		if !strings.Contains(body, want) {
+			t.Fatalf("response does not contain %q: %s", want, body)
+		}
+	}
+}
+
+func TestOTAFeaturePageIncludesProductionDetail(t *testing.T) {
+	handler := testServer(t, &memoryLeadStore{})
+
+	req := httptest.NewRequest(http.MethodGet, "/features/ota", nil)
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", rec.Code)
+	}
+
+	body := rec.Body.String()
+	for _, want := range []string{
+		"Upload signed firmware images and extract embedded project, version, model, checksum, and release-note metadata.",
+		"Target by product family, hardware model, current firmware version, customer tier, region, or support cohort.",
+		"Validate project and version compatibility before devices accept a package.",
+		"Choose the delivery mode that fits the release",
+		"<th scope=\"col\">Strategy</th>",
+		"Immediate, scheduled, user-controlled, and time-window rollout modes",
+		"Dynamic OTA keeps device eligibility aligned with the latest approved campaign even when endpoints reconnect later.",
+		"Cancel active waves and archive completed campaigns without losing audit history.",
 	} {
 		if !strings.Contains(body, want) {
 			t.Fatalf("response does not contain %q: %s", want, body)

--- a/static/styles.css
+++ b/static/styles.css
@@ -433,6 +433,10 @@ p {
   min-height: 300px;
 }
 
+.detail-panel > p:not(.eyebrow) {
+  margin: 14px 0 0;
+}
+
 .accent-panel {
   background: var(--bg-panel);
 }
@@ -459,6 +463,14 @@ p {
   height: 10px;
   border-radius: 50%;
   background: var(--brand);
+}
+
+.detail-table {
+  margin-top: 30px;
+}
+
+.supplemental-detail-grid {
+  margin-top: 0;
 }
 
 .contact-section {

--- a/templates/feature.html
+++ b/templates/feature.html
@@ -39,6 +39,57 @@
   </article>
 </section>
 
+{{if .Feature.Table.Rows}}
+<section class="section">
+  <div class="section-heading">
+    <p class="eyebrow">{{.Feature.Table.Eyebrow}}</p>
+    <h2>{{.Feature.Table.Title}}</h2>
+    <p class="section-lede">{{.Feature.Table.Intro}}</p>
+  </div>
+  <div class="table-wrap detail-table">
+    <table>
+      <thead>
+        <tr>
+          {{range .Feature.Table.Columns}}
+          <th scope="col">{{.}}</th>
+          {{end}}
+        </tr>
+      </thead>
+      <tbody>
+        {{range .Feature.Table.Rows}}
+        <tr>
+          {{range .Cells}}
+          <td>{{.}}</td>
+          {{end}}
+        </tr>
+        {{end}}
+      </tbody>
+    </table>
+  </div>
+</section>
+{{end}}
+
+{{if .Feature.Sections}}
+<section class="section">
+  <div class="detail-grid supplemental-detail-grid">
+    {{range .Feature.Sections}}
+    <article class="detail-panel{{if .Accent}} accent-panel{{end}}">
+      <p class="eyebrow">{{.Eyebrow}}</p>
+      <h2>{{.Title}}</h2>
+      {{if .Intro}}
+      <p>{{.Intro}}</p>
+      {{end}}
+      <ul class="check-list">
+        {{range .Items}}
+        <li>{{.}}</li>
+        {{end}}
+      </ul>
+    </article>
+    {{end}}
+  </div>
+</section>
+{{end}}
+
 <section class="cta-band">
   <div>
     <p class="eyebrow">Next step</p>


### PR DESCRIPTION
Refs #6

## Summary
- expand `/features/ota` with richer production-grade rollout copy covering firmware ingestion, metadata extraction, targeting, rollout modes, and operational safeguards
- add a structured rollout strategy table plus supplemental OTA workflow panels to the shared feature template
- update the parity spec and add regression coverage for the detailed OTA page content

## Validation
- `go test ./internal/web`
- `go test ./...`
- `go build ./cmd/server`
