### PR TITLE
Add smart home feature content

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Realtek Connect+ is a Go-rendered HTTP website for a Realtek-style IoT cloud pla
 
 Current status: **v0.1 Marketing Foundation**.
 
-This repository currently contains a working marketing website foundation, a developer docs portal structure, per-page SEO/social metadata, sitemap and robots endpoints, contact lead capture, SQLite storage, admin lead review with filtering and pagination, filtered CSV export, health check, and a container deployment recipe. It is not yet a complete ESP RainMaker parity website, IoT console, user authentication service, real OTA service, device provisioning backend, or telemetry platform.
+This repository currently contains a working marketing website foundation, a developer docs portal structure, feature pages for provisioning, OTA, fleet management, smart home experience, user management, app SDK, insights, private cloud, and integrations, per-page SEO/social metadata, sitemap and robots endpoints, contact lead capture, SQLite storage, admin lead review with filtering and pagination, filtered CSV export, health check, and a container deployment recipe. It is not yet a complete ESP RainMaker parity website, IoT console, user authentication service, real OTA service, device provisioning backend, or telemetry platform.
 
 The full roadmap and developer issue backlog live in [`docs/SPEC.md`](docs/SPEC.md).
 

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -19,7 +19,7 @@ Implemented today:
 - Generated hero/platform image stored in `static/assets/connectplus-hero.png`.
 - Per-page title, description, canonical, Open Graph, and Twitter card metadata.
 - Developer docs landing and detail pages covering Product Overview, Development, APIs, SDKs, Firmware, CLI, Deployment, and Release Notes.
-- Feature overview and detail pages for Provision, OTA, Fleet Management, User Management, App SDK, Insights, Private Cloud, and Integrations, including production-grade OTA rollout detail, a structured mobile app delivery comparison story, a structured private deployment comparison story, and ecosystem integration coverage across Matter Fabric, voice assistants, REST APIs, MQTT over TLS, and webhooks.
+- Feature overview and detail pages for Provision, OTA, Fleet Management, Smart Home Experience, User Management, App SDK, Insights, Private Cloud, and Integrations, including production-grade OTA rollout detail, a structured end-user smart-home workflow story, a structured mobile app delivery comparison story, a structured private deployment comparison story, and ecosystem integration coverage across Matter Fabric, voice assistants, REST APIs, MQTT over TLS, and webhooks.
 - `robots.txt` and `sitemap.xml` routes for crawl and link discovery.
 - Contact / early access registration form.
 - SQLite lead capture through `DATABASE_PATH`, defaulting to `data/connectplus.db`.
@@ -77,6 +77,7 @@ Realtek Connect+ presents the following ESP RainMaker-aligned capabilities:
 - Provision: Wi-Fi/BLE onboarding, device binding, activation, user-device association.
 - OTA: firmware upload, campaign rollout, job status, cancel/archive, version validation, and force/normal/scheduled/user-controlled/time-window rollout modes.
 - Fleet Management: device registry, groups, metadata/tags, batch operations, timezone, device sharing.
+- Smart Home Experience: remote control, local control fallback, schedules, scenes, grouping, node sharing, push notifications, alerts, and household sharing flows framed as product capabilities rather than current website app behavior.
 - User Management: sign up, sign in, OTP verification, third-party login, password recovery/change, and account deletion framed as platform capabilities rather than current website authentication flows.
 - App SDK: iOS/Android SDK layers, sample app and rebrand path, push notifications, app publishing path, and launch-readiness ownership boundaries.
 - Insights: activation statistics, firmware distribution, logs, crash reports, reboot reasons, RSSI/memory metrics.
@@ -99,7 +100,7 @@ Status values:
 | OTA | Implemented | `/features/ota` now covers firmware upload, extracted release metadata, model/version targeting, force/normal/scheduled/user-controlled/time-window rollouts, dynamic OTA eligibility, job detail, cancellation, archive flow, and a structured rollout strategy table. |
 | Fleet Management / Admin Operations | Implemented | `/features/fleet-management` now covers node registration, bootstrap certificates, device registry, groups, metadata, OTA jobs, firmware images, batch operations, operator statistics widgets, and the boundary between website lead admin and a future IoT platform console. |
 | User Management | Content Partial | Feature content now covers sign up, sign in, OTP verification, third-party login, forgot/change password, account deletion, and account lifecycle boundaries; follow-on work can add deeper support models, session behavior, and visual diagrams. |
-| End-user Smart Home Features | Planned | Add remote control, local control, scheduling, scenes, grouping, node sharing, push notifications, alerts, and mobile user workflows. |
+| End-user Smart Home Features | Content Partial | `/features/smart-home` now covers remote control, local control fallback, scheduling, scenes, grouping, node sharing, push notifications, alerts, and household workflow boundaries; follow-on work can add deeper visuals, control-state models, and persona-specific mobile flows. |
 | Mobile App SDK | Implemented | `/features/app-sdk` now covers iOS and Android SDK layers, sample app and rebrand paths, push notifications, App Store/Google Play publishing guidance, and a structured delivery-path comparison without introducing a client-side framework. |
 | Insights | Content Partial | Add logs, crash reports, reboot reasons, custom metrics, RSSI/memory metrics, firmware distribution, support workflows, and dashboard visuals. |
 | Private Cloud / Deployment | Implemented | `/features/private-cloud` now compares public evaluation, managed private deployment, and customer-operated private regions with explicit coverage for data ownership, custom domains, regional placement, upgrade path, deployment FAQ, and production support boundaries. |
@@ -138,6 +139,7 @@ Feature slugs:
 - `provision`
 - `ota`
 - `fleet-management`
+- `smart-home`
 - `user-management`
 - `app-sdk`
 - `insights`

--- a/internal/features/features.go
+++ b/internal/features/features.go
@@ -157,6 +157,62 @@ func All() []Feature {
 			},
 		},
 		{
+			Slug:         "smart-home",
+			Title:        "Smart Home Experience",
+			Kicker:       "Give end users clear control after onboarding.",
+			Summary:      "Remote control, local control fallback, schedules, scenes, grouping, device sharing, push notifications, and alerts for connected home products.",
+			Description:  "Smart Home Experience describes the consumer-facing product surface that sits on top of Realtek Connect+ cloud and app foundations. It covers how households control devices, automate routines, share access, and stay informed without implying that this marketing website is the shipped mobile app runtime.",
+			Highlights:   []string{"Remote and local control paths for everyday device actions", "Schedules, scenes, groups, and shared-home coordination", "Push notifications and alerts that bring users back into the branded app at the right moment"},
+			Capabilities: []string{"Device control surfaces for power, mode, status, and household context across mobile and local-network touchpoints", "Automation building blocks for recurring schedules, multi-device scenes, room or home grouping, and temporary or permanent node sharing", "Alert delivery for onboarding completion, offline state, abnormal events, maintenance reminders, and actionable support flows"},
+			Outcomes:     []string{"Make connected products feel useful after first setup", "Reduce support friction when households share devices or automate routines", "Show Realtek Connect+ as both an operator platform and an end-user product experience"},
+			Sections: []FeatureSection{
+				{
+					Eyebrow: "Control Modes",
+					Title:   "Support both cloud reach and at-home responsiveness",
+					Intro:   "The page frames control as a product experience with multiple paths instead of a single mobile button.",
+					Items: []string{
+						"Use remote control for away-from-home power, mode, and status changes when devices stay connected through the Realtek Connect+ cloud path.",
+						"Keep local control available on the home network so core actions can stay responsive during WAN degradation or when products intentionally prioritize nearby control.",
+						"Align these control surfaces with the branded app rather than implying that this Go website is the live smart-home client.",
+					},
+				},
+				{
+					Eyebrow: "Automation",
+					Title:   "Turn single devices into routines households can depend on",
+					Intro:   "Automation content focuses on the user workflows buyers expect once a product ships beyond basic provisioning.",
+					Items: []string{
+						"Create recurring schedules around daily routines, quiet hours, occupancy assumptions, or energy-saving windows.",
+						"Bundle scenes so users can trigger coordinated actions across lights, climate, appliances, or custom device categories from one tap.",
+						"Group devices by room, home, or product set so the app can present household-level control instead of one-node-at-a-time management.",
+					},
+				},
+				{
+					Eyebrow: "Household Sharing",
+					Title:   "Make multi-user homes manageable without losing accountability",
+					Intro:   "Sharing and notification flows are treated as part of the consumer product model, not as back-office admin tools.",
+					Items: []string{
+						"Support node sharing so primary owners can invite family members, installers, or temporary guests with bounded access expectations.",
+						"Use push notifications for onboarding completion, automation results, offline alerts, abnormal events, and OTA prompts that need the user back in the app.",
+						"Surface alerts with enough device and household context to help users act quickly without turning every product event into noise.",
+					},
+					Accent: true,
+				},
+			},
+			Table: FeatureTable{
+				Eyebrow: "End-user Workflows",
+				Title:   "Map the home experience to the right control pattern",
+				Intro:   "Realtek Connect+ uses this page to describe how households move between direct control, automation, and shared-home coordination while the website itself remains a product narrative.",
+				Columns: []string{"Workflow", "What the user does", "Why it matters", "Platform boundary"},
+				Rows: []FeatureTableRow{
+					{Cells: []string{"Remote control", "Open the branded app away from home to adjust power, mode, or device state through the cloud path.", "Keeps products useful when the user is not on the local network.", "Described as app and cloud capability scope; this repo does not ship the native control client."}},
+					{Cells: []string{"Local control", "Use home-network control paths for fast response and resilient fallback when internet conditions are poor.", "Improves perceived reliability for products that users expect to react immediately.", "Positioned as a product capability story layered on top of Realtek Connect+ device and app integration work."}},
+					{Cells: []string{"Schedules and scenes", "Set timed routines and multi-device actions that match household habits instead of manually repeating the same steps.", "Turns connected devices into repeatable home workflows instead of one-off remote commands.", "Automation behavior is described here without claiming a finished rules engine in this website runtime."}},
+					{Cells: []string{"Grouping and sharing", "Organize devices by room or home and invite additional household members into the right node set.", "Makes multi-device homes and multi-user access understandable at consumer scale.", "The marketing site explains the end-user model while leaving production identity and permissions to future app/platform implementations."}},
+					{Cells: []string{"Push notifications and alerts", "Receive actionable updates about onboarding, offline status, abnormal events, or pending actions that need attention.", "Brings users back into the app only when context matters and supports support-readiness planning.", "Notification delivery is presented as product capability scope, not as a promise that this website emits live device alerts today."}},
+				},
+			},
+		},
+		{
 			Slug:         "user-management",
 			Title:        "User Management",
 			Kicker:       "Handle the account lifecycle around connected products.",

--- a/internal/web/server_test.go
+++ b/internal/web/server_test.go
@@ -253,6 +253,54 @@ func TestFleetManagementFeatureCoversAdminOperationsScope(t *testing.T) {
 	}
 }
 
+func TestHomeAndSmartHomeFeatureCoverEndUserWorkflow(t *testing.T) {
+	handler := testServer(t, &memoryLeadStore{})
+
+	homeReq := httptest.NewRequest(http.MethodGet, "/", nil)
+	homeRec := httptest.NewRecorder()
+	handler.ServeHTTP(homeRec, homeReq)
+
+	if homeRec.Code != http.StatusOK {
+		t.Fatalf("home status = %d, want 200", homeRec.Code)
+	}
+	if !strings.Contains(homeRec.Body.String(), `/features/smart-home`) {
+		t.Fatalf("home page does not link to smart-home feature: %s", homeRec.Body.String())
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/features/smart-home", nil)
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", rec.Code)
+	}
+
+	body := rec.Body.String()
+	for _, want := range []string{
+		"Smart Home Experience",
+		"Remote control, local control fallback, schedules, scenes, grouping, device sharing, push notifications, and alerts for connected home products.",
+		"Use remote control for away-from-home power, mode, and status changes when devices stay connected through the Realtek Connect&#43; cloud path.",
+		"Keep local control available on the home network so core actions can stay responsive during WAN degradation or when products intentionally prioritize nearby control.",
+		"Create recurring schedules around daily routines, quiet hours, occupancy assumptions, or energy-saving windows.",
+		"Bundle scenes so users can trigger coordinated actions across lights, climate, appliances, or custom device categories from one tap.",
+		"Group devices by room, home, or product set so the app can present household-level control instead of one-node-at-a-time management.",
+		"Support node sharing so primary owners can invite family members, installers, or temporary guests with bounded access expectations.",
+		"Use push notifications for onboarding completion, automation results, offline alerts, abnormal events, and OTA prompts that need the user back in the app.",
+		"Map the home experience to the right control pattern",
+		"<th scope=\"col\">Workflow</th>",
+		"Remote control",
+		"Local control",
+		"Schedules and scenes",
+		"Grouping and sharing",
+		"Push notifications and alerts",
+		"this repo does not ship the native control client",
+	} {
+		if !strings.Contains(body, want) {
+			t.Fatalf("response does not contain %q: %s", want, body)
+		}
+	}
+}
+
 func TestUserManagementFeatureClarifiesPlatformScope(t *testing.T) {
 	handler := testServer(t, &memoryLeadStore{})
 


### PR DESCRIPTION
Refs #4

## Summary
- add a new server-rendered `/features/smart-home` page covering remote control, local control fallback, schedules, scenes, grouping, sharing, push notifications, and alerts
- rely on the shared feature list so the new capability is linked automatically from the homepage and feature overview
- update the parity matrix/spec wording and add regression coverage for the homepage link plus smart-home content

## Validation
- `gofmt -w internal/features/features.go internal/web/server_test.go`
- `go test ./internal/web -run 'TestRoutesReturnOK|TestHomeAndSmartHomeFeatureCoverEndUserWorkflow'`\n- `go test ./...`\n- `go build ./cmd/server`