### PR TITLE
Harden SQLite lead storage validation

### DIFF
--- a/internal/leads/repository.go
+++ b/internal/leads/repository.go
@@ -46,7 +46,7 @@ func NewRepository(db *sql.DB) *Repository {
 }
 
 func (r *Repository) Init() error {
-	_, err := r.db.Exec(`
+	if _, err := r.db.Exec(`
 CREATE TABLE IF NOT EXISTS leads (
   id INTEGER PRIMARY KEY AUTOINCREMENT,
   name TEXT NOT NULL,
@@ -55,19 +55,36 @@ CREATE TABLE IF NOT EXISTS leads (
   interest TEXT NOT NULL,
   message TEXT,
   created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP
-);`)
-	return err
+);`); err != nil {
+		return err
+	}
+
+	for _, statement := range []string{
+		leadValidationTriggerSQL("leads_validate_insert", "INSERT"),
+		leadValidationTriggerSQL("leads_validate_update", "UPDATE"),
+	} {
+		if _, err := r.db.Exec(statement); err != nil {
+			return err
+		}
+	}
+
+	return nil
 }
 
 func (r *Repository) Insert(ctx context.Context, lead Lead) error {
+	lead = Normalize(lead)
+	if validationErrs := Validate(lead); validationErrs != nil {
+		return validationErrs
+	}
+
 	_, err := r.db.ExecContext(ctx, `
 INSERT INTO leads (name, company, email, interest, message)
 VALUES (?, ?, ?, ?, ?)`,
-		strings.TrimSpace(lead.Name),
-		strings.TrimSpace(lead.Company),
-		strings.TrimSpace(lead.Email),
-		strings.TrimSpace(lead.Interest),
-		strings.TrimSpace(lead.Message),
+		lead.Name,
+		lead.Company,
+		lead.Email,
+		lead.Interest,
+		lead.Message,
 	)
 	return err
 }
@@ -182,4 +199,23 @@ func parseSQLiteTime(value string) time.Time {
 		}
 	}
 	return time.Time{}
+}
+
+func leadValidationTriggerSQL(name, operation string) string {
+	return `
+CREATE TRIGGER IF NOT EXISTS ` + name + `
+BEFORE ` + operation + ` ON leads
+FOR EACH ROW
+BEGIN
+  SELECT CASE
+    WHEN length(trim(COALESCE(NEW.name, ''))) = 0 THEN RAISE(ABORT, 'lead name is required')
+    WHEN length(trim(COALESCE(NEW.name, ''))) > 120 THEN RAISE(ABORT, 'lead name exceeds 120 characters')
+    WHEN length(trim(COALESCE(NEW.company, ''))) > 160 THEN RAISE(ABORT, 'lead company exceeds 160 characters')
+    WHEN length(trim(COALESCE(NEW.email, ''))) = 0 THEN RAISE(ABORT, 'lead email is required')
+    WHEN length(trim(COALESCE(NEW.email, ''))) > 254 THEN RAISE(ABORT, 'lead email exceeds 254 characters')
+    WHEN length(trim(COALESCE(NEW.interest, ''))) = 0 THEN RAISE(ABORT, 'lead interest is required')
+    WHEN length(trim(COALESCE(NEW.interest, ''))) > 120 THEN RAISE(ABORT, 'lead interest exceeds 120 characters')
+    WHEN length(trim(COALESCE(NEW.message, ''))) > 2000 THEN RAISE(ABORT, 'lead message exceeds 2000 characters')
+  END;
+END;`
 }

--- a/internal/leads/repository_test.go
+++ b/internal/leads/repository_test.go
@@ -3,6 +3,7 @@ package leads
 import (
 	"context"
 	"database/sql"
+	"strings"
 	"testing"
 
 	_ "modernc.org/sqlite"
@@ -21,11 +22,11 @@ func TestRepositoryInsert(t *testing.T) {
 	}
 
 	if err := repo.Insert(context.Background(), Lead{
-		Name:     "Kevin Huang",
-		Company:  "Realtek",
-		Email:    "kevin@example.com",
-		Interest: "OTA",
-		Message:  "Interested in rollout control.",
+		Name:     "  Kevin Huang  ",
+		Company:  "  Realtek  ",
+		Email:    "  kevin@example.com  ",
+		Interest: "  OTA  ",
+		Message:  "  Interested in rollout control.  ",
 	}); err != nil {
 		t.Fatalf("insert lead: %v", err)
 	}
@@ -45,8 +46,20 @@ func TestRepositoryInsert(t *testing.T) {
 	if len(records) != 1 {
 		t.Fatalf("records = %d, want 1", len(records))
 	}
+	if records[0].Name != "Kevin Huang" {
+		t.Fatalf("name = %q, want Kevin Huang", records[0].Name)
+	}
+	if records[0].Company != "Realtek" {
+		t.Fatalf("company = %q, want Realtek", records[0].Company)
+	}
 	if records[0].Email != "kevin@example.com" {
 		t.Fatalf("email = %q, want kevin@example.com", records[0].Email)
+	}
+	if records[0].Interest != "OTA" {
+		t.Fatalf("interest = %q, want OTA", records[0].Interest)
+	}
+	if records[0].Message != "Interested in rollout control." {
+		t.Fatalf("message = %q, want trimmed value", records[0].Message)
 	}
 	if records[0].CreatedAt.IsZero() {
 		t.Fatal("created_at was not parsed")
@@ -119,5 +132,88 @@ func TestRepositoryListSupportsFilteringAndPagination(t *testing.T) {
 	}
 	if records[0].Email != "beta@example.com" {
 		t.Fatalf("email = %q, want beta@example.com", records[0].Email)
+	}
+}
+
+func TestRepositoryInsertRejectsInvalidLead(t *testing.T) {
+	db, err := sql.Open("sqlite", ":memory:")
+	if err != nil {
+		t.Fatalf("open sqlite: %v", err)
+	}
+	defer db.Close()
+
+	repo := NewRepository(db)
+	if err := repo.Init(); err != nil {
+		t.Fatalf("init schema: %v", err)
+	}
+
+	err = repo.Insert(context.Background(), Lead{
+		Name:     strings.Repeat("N", NameMaxLength+1),
+		Company:  "Realtek",
+		Email:    "kevin@example.com",
+		Interest: "",
+		Message:  strings.Repeat("M", MessageMaxLength+1),
+	})
+	if err == nil {
+		t.Fatal("expected validation error")
+	}
+
+	validationErrs, ok := err.(ValidationErrors)
+	if !ok {
+		t.Fatalf("error type = %T, want ValidationErrors", err)
+	}
+	if validationErrs["name"] != "Name must be 120 characters or fewer." {
+		t.Fatalf("name error = %q", validationErrs["name"])
+	}
+	if validationErrs["interest"] != "Select an area of interest." {
+		t.Fatalf("interest error = %q", validationErrs["interest"])
+	}
+	if validationErrs["message"] != "Message must be 2000 characters or fewer." {
+		t.Fatalf("message error = %q", validationErrs["message"])
+	}
+
+	count, err := repo.Count(context.Background(), ListFilter{})
+	if err != nil {
+		t.Fatalf("count leads: %v", err)
+	}
+	if count != 0 {
+		t.Fatalf("count = %d, want 0", count)
+	}
+}
+
+func TestRepositoryInitAddsSQLiteValidationGuards(t *testing.T) {
+	db, err := sql.Open("sqlite", ":memory:")
+	if err != nil {
+		t.Fatalf("open sqlite: %v", err)
+	}
+	defer db.Close()
+
+	repo := NewRepository(db)
+	if err := repo.Init(); err != nil {
+		t.Fatalf("init schema: %v", err)
+	}
+
+	_, err = db.ExecContext(context.Background(), `
+INSERT INTO leads (name, company, email, interest, message)
+VALUES (?, ?, ?, ?, ?)`,
+		"Kevin Huang",
+		"Realtek",
+		"kevin@example.com",
+		"OTA",
+		strings.Repeat("M", MessageMaxLength+1),
+	)
+	if err == nil {
+		t.Fatal("expected sqlite validation error")
+	}
+	if !strings.Contains(err.Error(), "lead message exceeds 2000 characters") {
+		t.Fatalf("error = %v, want message length guard", err)
+	}
+
+	count, err := repo.Count(context.Background(), ListFilter{})
+	if err != nil {
+		t.Fatalf("count leads: %v", err)
+	}
+	if count != 0 {
+		t.Fatalf("count = %d, want 0", count)
 	}
 }

--- a/internal/leads/repository_test.go
+++ b/internal/leads/repository_test.go
@@ -181,6 +181,38 @@ func TestRepositoryInsertRejectsInvalidLead(t *testing.T) {
 	}
 }
 
+func TestRepositoryInsertAcceptsUnicodeAtCharacterLimit(t *testing.T) {
+	db, err := sql.Open("sqlite", ":memory:")
+	if err != nil {
+		t.Fatalf("open sqlite: %v", err)
+	}
+	defer db.Close()
+
+	repo := NewRepository(db)
+	if err := repo.Init(); err != nil {
+		t.Fatalf("init schema: %v", err)
+	}
+
+	err = repo.Insert(context.Background(), Lead{
+		Name:     strings.Repeat("界", NameMaxLength),
+		Company:  strings.Repeat("公", CompanyMaxLength),
+		Email:    "unicode@example.com",
+		Interest: strings.Repeat("类", InterestMaxLength),
+		Message:  strings.Repeat("文", MessageMaxLength),
+	})
+	if err != nil {
+		t.Fatalf("insert unicode lead: %v", err)
+	}
+
+	count, err := repo.Count(context.Background(), ListFilter{})
+	if err != nil {
+		t.Fatalf("count leads: %v", err)
+	}
+	if count != 1 {
+		t.Fatalf("count = %d, want 1", count)
+	}
+}
+
 func TestRepositoryInitAddsSQLiteValidationGuards(t *testing.T) {
 	db, err := sql.Open("sqlite", ":memory:")
 	if err != nil {

--- a/internal/leads/validation.go
+++ b/internal/leads/validation.go
@@ -3,6 +3,7 @@ package leads
 import (
 	"sort"
 	"strings"
+	"unicode/utf8"
 )
 
 const (
@@ -43,27 +44,27 @@ func Validate(lead Lead) ValidationErrors {
 	errors := ValidationErrors{}
 	if lead.Name == "" {
 		errors["name"] = "Name is required."
-	} else if len(lead.Name) > NameMaxLength {
+	} else if fieldLength(lead.Name) > NameMaxLength {
 		errors["name"] = "Name must be 120 characters or fewer."
 	}
 
 	if lead.Email == "" {
 		errors["email"] = "Email is required."
-	} else if len(lead.Email) > EmailMaxLength {
+	} else if fieldLength(lead.Email) > EmailMaxLength {
 		errors["email"] = "Email must be 254 characters or fewer."
 	}
 
 	if lead.Interest == "" {
 		errors["interest"] = "Select an area of interest."
-	} else if len(lead.Interest) > InterestMaxLength {
+	} else if fieldLength(lead.Interest) > InterestMaxLength {
 		errors["interest"] = "Interest must be 120 characters or fewer."
 	}
 
-	if len(lead.Company) > CompanyMaxLength {
+	if fieldLength(lead.Company) > CompanyMaxLength {
 		errors["company"] = "Company must be 160 characters or fewer."
 	}
 
-	if len(lead.Message) > MessageMaxLength {
+	if fieldLength(lead.Message) > MessageMaxLength {
 		errors["message"] = "Message must be 2000 characters or fewer."
 	}
 
@@ -71,4 +72,8 @@ func Validate(lead Lead) ValidationErrors {
 		return nil
 	}
 	return errors
+}
+
+func fieldLength(value string) int {
+	return utf8.RuneCountInString(value)
 }

--- a/internal/leads/validation.go
+++ b/internal/leads/validation.go
@@ -1,0 +1,74 @@
+package leads
+
+import (
+	"sort"
+	"strings"
+)
+
+const (
+	NameMaxLength     = 120
+	CompanyMaxLength  = 160
+	EmailMaxLength    = 254
+	InterestMaxLength = 120
+	MessageMaxLength  = 2000
+)
+
+type ValidationErrors map[string]string
+
+func (e ValidationErrors) Error() string {
+	if len(e) == 0 {
+		return ""
+	}
+
+	parts := make([]string, 0, len(e))
+	for field, message := range e {
+		parts = append(parts, field+": "+message)
+	}
+	sort.Strings(parts)
+	return "invalid lead: " + strings.Join(parts, "; ")
+}
+
+func Normalize(lead Lead) Lead {
+	lead.Name = strings.TrimSpace(lead.Name)
+	lead.Company = strings.TrimSpace(lead.Company)
+	lead.Email = strings.TrimSpace(lead.Email)
+	lead.Interest = strings.TrimSpace(lead.Interest)
+	lead.Message = strings.TrimSpace(lead.Message)
+	return lead
+}
+
+func Validate(lead Lead) ValidationErrors {
+	lead = Normalize(lead)
+
+	errors := ValidationErrors{}
+	if lead.Name == "" {
+		errors["name"] = "Name is required."
+	} else if len(lead.Name) > NameMaxLength {
+		errors["name"] = "Name must be 120 characters or fewer."
+	}
+
+	if lead.Email == "" {
+		errors["email"] = "Email is required."
+	} else if len(lead.Email) > EmailMaxLength {
+		errors["email"] = "Email must be 254 characters or fewer."
+	}
+
+	if lead.Interest == "" {
+		errors["interest"] = "Select an area of interest."
+	} else if len(lead.Interest) > InterestMaxLength {
+		errors["interest"] = "Interest must be 120 characters or fewer."
+	}
+
+	if len(lead.Company) > CompanyMaxLength {
+		errors["company"] = "Company must be 160 characters or fewer."
+	}
+
+	if len(lead.Message) > MessageMaxLength {
+		errors["message"] = "Message must be 2000 characters or fewer."
+	}
+
+	if len(errors) == 0 {
+		return nil
+	}
+	return errors
+}

--- a/internal/leads/validation_test.go
+++ b/internal/leads/validation_test.go
@@ -1,0 +1,48 @@
+package leads
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestValidateCountsUnicodeCharacters(t *testing.T) {
+	valid := Lead{
+		Name:     strings.Repeat("界", NameMaxLength),
+		Company:  strings.Repeat("公", CompanyMaxLength),
+		Email:    "unicode@example.com",
+		Interest: strings.Repeat("类", InterestMaxLength),
+		Message:  strings.Repeat("文", MessageMaxLength),
+	}
+
+	if err := Validate(valid); err != nil {
+		t.Fatalf("validate valid unicode lead: %v", err)
+	}
+
+	invalid := Lead{
+		Name:     strings.Repeat("界", NameMaxLength+1),
+		Company:  strings.Repeat("公", CompanyMaxLength+1),
+		Email:    strings.Repeat("é", EmailMaxLength+1),
+		Interest: strings.Repeat("类", InterestMaxLength+1),
+		Message:  strings.Repeat("文", MessageMaxLength+1),
+	}
+
+	errs := Validate(invalid)
+	if errs == nil {
+		t.Fatal("expected validation errors")
+	}
+	if errs["name"] != "Name must be 120 characters or fewer." {
+		t.Fatalf("name error = %q", errs["name"])
+	}
+	if errs["company"] != "Company must be 160 characters or fewer." {
+		t.Fatalf("company error = %q", errs["company"])
+	}
+	if errs["email"] != "Email must be 254 characters or fewer." {
+		t.Fatalf("email error = %q", errs["email"])
+	}
+	if errs["interest"] != "Interest must be 120 characters or fewer." {
+		t.Fatalf("interest error = %q", errs["interest"])
+	}
+	if errs["message"] != "Message must be 2000 characters or fewer." {
+		t.Fatalf("message error = %q", errs["message"])
+	}
+}

--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -71,14 +71,7 @@ type contactForm struct {
 	Website  string
 }
 
-const (
-	contactNameMaxLength     = 120
-	contactCompanyMaxLength  = 160
-	contactEmailMaxLength    = 254
-	contactInterestMaxLength = 120
-	contactMessageMaxLength  = 2000
-	adminLeadPageSize        = 25
-)
+const adminLeadPageSize = 25
 
 type adminLeadFilters struct {
 	Email     string
@@ -475,29 +468,23 @@ func (s *Server) submitContact(w http.ResponseWriter, r *http.Request) {
 }
 
 func validateContact(form contactForm) map[string]string {
-	errors := map[string]string{}
-	if form.Name == "" {
-		errors["name"] = "Name is required."
-	} else if len(form.Name) > contactNameMaxLength {
-		errors["name"] = "Name must be 120 characters or fewer."
+	errors := make(map[string]string)
+	for field, message := range leads.Validate(leads.Lead{
+		Name:     form.Name,
+		Company:  form.Company,
+		Email:    form.Email,
+		Interest: form.Interest,
+		Message:  form.Message,
+	}) {
+		errors[field] = message
 	}
-	if form.Email == "" {
-		errors["email"] = "Email is required."
-	} else if !emailPattern.MatchString(form.Email) {
+
+	if form.Email != "" && !emailPattern.MatchString(form.Email) {
 		errors["email"] = "Enter a valid email address."
-	} else if len(form.Email) > contactEmailMaxLength {
-		errors["email"] = "Email must be 254 characters or fewer."
 	}
-	if form.Interest == "" {
-		errors["interest"] = "Select an area of interest."
-	} else if len(form.Interest) > contactInterestMaxLength {
-		errors["interest"] = "Interest must be 120 characters or fewer."
-	}
-	if len(form.Company) > contactCompanyMaxLength {
-		errors["company"] = "Company must be 160 characters or fewer."
-	}
-	if len(form.Message) > contactMessageMaxLength {
-		errors["message"] = "Message must be 2000 characters or fewer."
+
+	if len(errors) == 0 {
+		return nil
 	}
 	return errors
 }

--- a/internal/web/server_test.go
+++ b/internal/web/server_test.go
@@ -605,11 +605,11 @@ func TestOversizedContactPostDoesNotStoreLead(t *testing.T) {
 	handler := testServer(t, store)
 
 	form := url.Values{
-		"name":     {strings.Repeat("N", contactNameMaxLength+1)},
-		"company":  {strings.Repeat("C", contactCompanyMaxLength+1)},
+		"name":     {strings.Repeat("N", leads.NameMaxLength+1)},
+		"company":  {strings.Repeat("C", leads.CompanyMaxLength+1)},
 		"email":    {"kevin@example.com"},
 		"interest": {"OTA"},
-		"message":  {strings.Repeat("M", contactMessageMaxLength+1)},
+		"message":  {strings.Repeat("M", leads.MessageMaxLength+1)},
 	}
 	req := httptest.NewRequest(http.MethodPost, "/contact", strings.NewReader(form.Encode()))
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")


### PR DESCRIPTION
## Summary
- centralize lead normalization and required/max-length validation in `internal/leads`
- apply the same guards in the repository layer before inserts and add SQLite triggers so direct writes cannot bypass them
- extend repository regression coverage for trimming, invalid lead rejection, and oversized direct SQLite inserts

## Validation
- `gofmt -w internal/leads/validation.go internal/leads/repository.go internal/leads/repository_test.go internal/web/server.go internal/web/server_test.go`
- `go test ./internal/leads ./internal/web`
- `go test ./...`
- `go build ./cmd/server`

Refs #13