### PR TITLE
Align provisioning copy with contract status

### DIFF
--- a/cmd/visual-smoke/main.go
+++ b/cmd/visual-smoke/main.go
@@ -133,7 +133,7 @@ func main() {
 			imageSelector:    ".feature-visual img",
 			expectedHeading:  "Provision 配網",
 			expectedTitle:    "Provision 配網 | Realtek Connect+",
-			expectedBodyText: "降低裝置導入與綁定摩擦",
+			expectedBodyText: "合約支撐的基礎",
 		},
 		{
 			name:             "feature-zh-cn",
@@ -142,7 +142,7 @@ func main() {
 			imageSelector:    ".feature-visual img",
 			expectedHeading:  "Provision 配网",
 			expectedTitle:    "Provision 配网 | Realtek Connect+",
-			expectedBodyText: "降低装置导入与绑定摩擦",
+			expectedBodyText: "合约支撑的基础",
 		},
 	}
 

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -188,7 +188,7 @@ The matrix below tracks website v1 representation, not live cloud-service implem
 | Capability | Website v1 Status | Current Surface | Website v1 Notes |
 | --- | --- | --- | --- |
 | Platform Overview | Content Partial | Homepage, `/features`, docs landing page | The site now explains the device-cloud-app-dashboard story, but follow-on work can deepen security, scalability, cost, and deployment comparison narratives. |
-| Provision | Content Partial | `/features/provision` | Provisioning copy covers Wi-Fi/BLE onboarding, activation, binding, and account association, but it still needs QR/SoftAP diagrams, failure-state coverage, and deeper claiming workflow detail. |
+| Provision | Content Partial | `/features/provision`, [`PRODUCT_ONBOARDING.md`](https://github.com/hkt999rtk/rtk_cloud_contracts_doc/blob/main/PRODUCT_ONBOARDING.md) | Provisioning copy now distinguishes the contract-backed cloud registry, cross-service activation, scoped-token, and transport-readiness foundation from integration-ready claim material interfaces and roadmap local onboarding work. Local Wi-Fi/BLE setup, QR/SoftAP UX, ownership transfer, factory reset policy, and aggregate product readiness are not described as generally available until the owner repositories land those implementations. |
 | OTA | Implemented | `/features/ota` | The OTA page now covers firmware upload, extracted release metadata, model/version targeting, force/normal/scheduled/user-controlled/time-window rollouts, dynamic OTA eligibility, job detail, cancellation, archive flow, and a rollout strategy table. |
 | Fleet Management | Implemented | `/features/fleet-management` | The fleet page covers node registration, bootstrap certificates, registry, groups, metadata, OTA jobs, firmware images, batch operations, and operator statistics widgets as website content without claiming a live console implementation. |
 | Admin Operations | Content Partial | `/features/fleet-management`, `/admin/leads`, `/admin/leads.csv` | Website v1 ships lead-review tooling plus admin-operations product copy, but it does not ship the full fleet console described by the marketing content. |
@@ -242,7 +242,7 @@ Localized public route variants:
 
 Feature slugs:
 
-- `provision`
+- `provision`: aligns public provisioning availability wording with the product onboarding interface contract, separating the cloud-side activation foundation from integration-ready claim material and roadmap local onboarding/readiness work.
 - `ota`
 - `fleet-management`
 - `smart-home`

--- a/internal/content/content_test.go
+++ b/internal/content/content_test.go
@@ -57,3 +57,11 @@ func TestLocaleFromPath(t *testing.T) {
 		}
 	}
 }
+
+func TestToSimplifiedCoversProvisioningContractTerms(t *testing.T) {
+	got := ToSimplified("合約支撐的基礎")
+	want := "合约支撑的基础"
+	if got != want {
+		t.Fatalf("ToSimplified() = %q, want %q", got, want)
+	}
+}

--- a/internal/content/zh.go
+++ b/internal/content/zh.go
@@ -242,13 +242,13 @@ func zhTWFeatures() map[string]localizedFeature {
 	return map[string]localizedFeature{
 		"provision": {
 			Title:        "Provision 配網",
-			Kicker:       "降低裝置導入與綁定摩擦。",
-			Summary:      "為 Realtek 物聯網產品提供安全 Wi-Fi/BLE 配網、啟用與帳號綁定流程。",
-			Description:  "Provision 讓產品團隊能從出廠硬體一路走到使用者擁有的連網裝置，涵蓋首次啟用、本地配網、雲端登錄與使用者裝置關聯。",
-			ImageAlt:     "顯示手機配對、QR 導入與裝置啟用狀態卡片的配網儀表板。",
-			Highlights:   []string{"Wi-Fi 與 BLE 配網流程", "裝置綁定與所有權轉移", "啟用狀態與首次遙測"},
-			Capabilities: []string{"Claim token 與裝置身分交接", "App 導入流程中的使用者裝置關聯", "時區與中繼資料初始化"},
-			Outcomes:     []string{"降低設定失敗率", "縮短 App 導入時間", "讓裝置準備進入營運管理"},
+			Kicker:       "以合約支撐的基礎來描述裝置導入。",
+			Summary:      "雲端 registry 與啟用基礎已有合約邊界；本地 Wi-Fi/BLE 配網、claim UX、轉移/重設政策與完整產品就緒狀態仍屬整合或 roadmap 範圍。",
+			Description:  "Provision 將 Realtek Connect+ 導入描述為從 registry 到雲端啟用裝置的分層流程。現階段可對外說明的是帳號 registry、跨服務 provision command、video cloud 啟用邊界、scoped token 與 transport readiness 合約；本地 Wi-Fi/BLE 設定、QR/SoftAP UX、所有權轉移、factory reset 政策與彙整產品就緒狀態，在負責 repo 完成前不描述為全面可用實作。",
+			ImageAlt:     "顯示手機配對、QR 導入與裝置啟用狀態卡片的配網概念儀表板。",
+			Highlights:   []string{"雲端 registry、啟用、token 與 transport readiness 的合約邊界", "QR、序號、activation code 與未來 factory identity 的 claim material 概念", "本地 Wi-Fi/BLE、SoftAP UX、轉移/重設政策與彙整 readiness 維持 roadmap 標示"},
+			Capabilities: []string{"以帳號 registry API 與跨服務 DeviceProvisionRequested、DeviceProvisionSucceeded 或 DeviceProvisionFailed 事件描述雲端啟用基礎", "將 SDK claim parsing 與帳號端所有權及綁定政策分開", "把本地配網與產品就緒狀態描述為規劃中的 owner-repo 工作，而非網站已全面提供的功能"},
+			Outcomes:     []string{"保留產品導入願景且不誇大實作狀態", "讓 firmware、App、SDK、account 與 video cloud 團隊共用 availability 詞彙", "讓評估討論清楚區分目前可用、整合就緒與 roadmap"},
 		},
 		"ota": {
 			Title:        "OTA 韌體更新",
@@ -495,7 +495,7 @@ func toSimplified(value string) string {
 		"業", "业", "術", "术", "載", "载", "詢", "询", "問", "问", "聲", "声",
 		"單", "单", "聲明", "声明", "處理", "处理", "聯絡", "联络", "請求", "请求",
 		"預", "预", "期", "期", "個月", "个月", "訊息", "讯息", "嵌", "嵌",
-		"瀏", "浏",
+		"瀏", "浏", "約", "约", "撐", "撑",
 	)
 	return replacer.Replace(value)
 }

--- a/internal/features/features.go
+++ b/internal/features/features.go
@@ -9,6 +9,8 @@ type Feature struct {
 	Description  string
 	ImagePath    string
 	ImageAlt     string
+	SourceLabel  string
+	SourceURL    string
 	Highlights   []string
 	Capabilities []string
 	Outcomes     []string
@@ -42,14 +44,61 @@ func All() []Feature {
 			Slug:         "provision",
 			Title:        "Provision",
 			Icon:         "provision",
-			Kicker:       "Onboard devices with less product friction.",
-			Summary:      "Secure Wi-Fi/BLE onboarding, activation, and account binding for Realtek-based IoT products.",
-			Description:  "Provision gives product teams a repeatable path from factory-ready hardware to a user-owned connected device. It covers first-time activation, local onboarding, cloud registration, and user-device association.",
+			Kicker:       "Frame onboarding around the contract-backed foundation.",
+			Summary:      "Cloud registry and activation foundations are contract-backed; local Wi-Fi/BLE onboarding, claim UX, transfer/reset policy, and product readiness remain integration or roadmap scope.",
+			Description:  "Provision presents Realtek Connect+ onboarding as a layered path from registry entry to activated cloud device. The current foundation is the account registry, cross-service provisioning command flow, video-cloud activation boundary, scoped tokens, and transport readiness contract; local Wi-Fi/BLE setup, QR/SoftAP UX, ownership transfer, factory reset policy, and aggregate product readiness are not presented as generally available implementation until those owner repositories land them.",
 			ImagePath:    "/static/assets/feature-provision-flow.jpg",
-			ImageAlt:     "Provisioning dashboard with mobile pairing steps, QR onboarding, and device activation status cards.",
-			Highlights:   []string{"Wi-Fi and BLE onboarding flows", "Device binding and ownership transfer", "Activation state and first-run telemetry"},
-			Capabilities: []string{"Claiming tokens and device identity handoff", "User-device association during app onboarding", "Timezone and metadata initialization"},
-			Outcomes:     []string{"Reduce setup failures", "Shorten app onboarding", "Prepare devices for fleet operations"},
+			ImageAlt:     "Provisioning dashboard concept with mobile pairing steps, QR onboarding, and device activation status cards.",
+			SourceLabel:  "Product onboarding interface contract",
+			SourceURL:    "https://github.com/hkt999rtk/rtk_cloud_contracts_doc/blob/main/PRODUCT_ONBOARDING.md",
+			Highlights:   []string{"Contract-backed cloud registry, activation, token, and transport readiness boundaries", "Integration-ready claim material concepts for QR, serial, activation code, and future factory identity", "Roadmap treatment for local Wi-Fi/BLE setup, SoftAP UX, transfer/reset policy, and aggregate readiness"},
+			Capabilities: []string{"Use account-side registry APIs plus cross-service DeviceProvisionRequested and DeviceProvisionSucceeded or DeviceProvisionFailed events for the cloud activation foundation", "Keep SDK claim parsing separate from account-side ownership and binding decisions", "Describe local onboarding and product readiness as planned owner-repository work instead of broadly available website functionality"},
+			Outcomes:     []string{"Preserve the product onboarding vision without overclaiming implementation status", "Give firmware, app, SDK, account, and video-cloud teams one shared availability vocabulary", "Make evaluation conversations explicit about what is available now, integration-ready, or roadmap"},
+			Sections: []FeatureSection{
+				{
+					Eyebrow: "Available foundation",
+					Title:   "Cloud-side provisioning is the implemented contract boundary",
+					Intro:   "The stable story starts with account registry records and the cross-service activation flow rather than a single all-in-one provisioning endpoint.",
+					Items: []string{
+						"Account-side device registration, cross-service provisioning requests, video activation results, scoped token issuance, and owner transport readiness are the public cloud-side behaviors to discuss today.",
+						"Provisioning remains multi-service orchestration across account manager, the cross-service channel, video cloud, device credentials, and transport state.",
+						"Video activation alone is not full product readiness; the product state must distinguish registry, claim, local setup, activation, online, failure, and deactivation stages.",
+					},
+				},
+				{
+					Eyebrow: "Integration-ready",
+					Title:   "Claim material has a defined interface, not final ownership policy",
+					Intro:   "The product onboarding contract gives SDK and app teams common vocabulary for claim input while leaving authorization decisions with account-side policy.",
+					Items: []string{
+						"Claim material may represent QR payloads, serial numbers, activation codes, MAC addresses, or future factory identity inputs.",
+						"SDK parsers should normalize supported claim material and return stable errors for malformed or unsupported inputs.",
+						"Account-side follow-up work still owns reuse rules, already-claimed rejection, transfer behavior, factory reset semantics, and delete-versus-deactivate policy.",
+					},
+				},
+				{
+					Eyebrow: "Roadmap",
+					Title:   "Local onboarding remains owner-repository implementation work",
+					Intro:   "The public page keeps the product vision visible while avoiding a general-availability claim for local setup UX.",
+					Items: []string{
+						"BLE provisioning, SoftAP provisioning, local Wi-Fi credential transport, QR onboarding UX, ECDH or challenge-response handshakes, and manufacturing CA policy are not yet stable website-available implementation claims.",
+						"Android and iOS are the primary targets for real local onboarding implementations; native and JavaScript/TypeScript packages should report explicit unsupported capability where needed.",
+						"Full product readiness should wait for local setup results, claim/bind policy, cloud activation, and transport online state to be joined by an owner repository or integration service.",
+					},
+					Accent: true,
+				},
+			},
+			Table: FeatureTable{
+				Eyebrow: "Availability",
+				Title:   "Separate what is available, integration-ready, and roadmap",
+				Intro:   "Realtek Connect+ provisioning is presented as a layered product path. The cloud-side foundation is contract-backed now; local onboarding UX and final ownership policy stay clearly marked until implementation lands.",
+				Columns: []string{"Layer", "Public status", "Customer-facing boundary"},
+				Rows: []FeatureTableRow{
+					{Cells: []string{"Cloud registry and activation foundation", "Available foundation", "Account registry, cross-service provisioning commands and events, video activation, scoped credentials, and transport readiness define the current cloud-side path."}},
+					{Cells: []string{"Claim material parsing", "Integration-ready", "QR, serial, activation code, MAC, and future factory identity inputs have shared interface vocabulary, but ownership policy is account-side follow-up work."}},
+					{Cells: []string{"Local Wi-Fi/BLE and SoftAP onboarding", "Roadmap", "Local discovery, credential handoff, QR onboarding UX, and mobile setup sessions are not described as generally available implementation in this website."}},
+					{Cells: []string{"Transfer, reset, and product readiness", "Roadmap", "Already-claimed handling, ownership transfer, factory reset, delete/deactivate separation, and aggregate readiness projection require follow-up policy and service work."}},
+				},
+			},
 		},
 		{
 			Slug:         "ota",

--- a/internal/web/icons.go
+++ b/internal/web/icons.go
@@ -21,6 +21,7 @@ var iconPaths = map[string]string{
 	"device":      `<rect x="7" y="3" width="10" height="18" rx="2"/><path d="M10 17h4"/><path d="M10 7h4"/>`,
 	"document":    `<path d="M7 3h7l4 4v14H7z"/><path d="M14 3v5h5"/><path d="M10 12h6"/><path d="M10 16h6"/>`,
 	"download":    `<path d="M12 4v10"/><path d="m8 10 4 4 4-4"/><path d="M5 20h14"/>`,
+	"external":    `<path d="M14 4h6v6"/><path d="m10 14 10-10"/><path d="M20 14v5a1 1 0 0 1-1 1H5a1 1 0 0 1-1-1V5a1 1 0 0 1 1-1h5"/>`,
 	"filter":      `<path d="M4 6h16"/><path d="M7 12h10"/><path d="M10 18h4"/>`,
 	"fleet":       `<rect x="4" y="4" width="5" height="5" rx="1"/><rect x="15" y="4" width="5" height="5" rx="1"/><rect x="4" y="15" width="5" height="5" rx="1"/><rect x="15" y="15" width="5" height="5" rx="1"/><path d="M9 6.5h6"/><path d="M6.5 9v6"/><path d="M17.5 9v6"/><path d="M9 17.5h6"/>`,
 	"grid":        `<rect x="4" y="4" width="6" height="6" rx="1"/><rect x="14" y="4" width="6" height="6" rx="1"/><rect x="4" y="14" width="6" height="6" rx="1"/><rect x="14" y="14" width="6" height="6" rx="1"/>`,

--- a/internal/web/server_test.go
+++ b/internal/web/server_test.go
@@ -186,7 +186,7 @@ func TestLocalizedHomeIncludesLangSwitcherAndAlternates(t *testing.T) {
 		`hreflang="x-default" href="http://example.com/features/provision"`,
 		`href="http://example.com/zh-tw/features/provision" aria-current="true">繁體中文</a>`,
 		"Provision 配網",
-		"降低裝置導入與綁定摩擦。",
+		"以合約支撐的基礎來描述裝置導入。",
 	} {
 		if !strings.Contains(body, want) {
 			t.Fatalf("response does not contain %q: %s", want, body)
@@ -598,6 +598,39 @@ func TestOTAFeaturePageIncludesProductionDetail(t *testing.T) {
 	}
 }
 
+func TestProvisionFeatureAlignsPublicCopyWithContractStatus(t *testing.T) {
+	handler := testServer(t, &memoryLeadStore{})
+
+	req := httptest.NewRequest(http.MethodGet, "/features/provision", nil)
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", rec.Code)
+	}
+
+	body := rec.Body.String()
+	for _, want := range []string{
+		"Cloud registry and activation foundations are contract-backed; local Wi-Fi/BLE onboarding, claim UX, transfer/reset policy, and product readiness remain integration or roadmap scope.",
+		"Product onboarding interface contract",
+		`href="https://github.com/hkt999rtk/rtk_cloud_contracts_doc/blob/main/PRODUCT_ONBOARDING.md"`,
+		"Cloud-side provisioning is the implemented contract boundary",
+		"Account-side device registration, cross-service provisioning requests, video activation results, scoped token issuance, and owner transport readiness are the public cloud-side behaviors to discuss today.",
+		"Claim material has a defined interface, not final ownership policy",
+		"BLE provisioning, SoftAP provisioning, local Wi-Fi credential transport, QR onboarding UX, ECDH or challenge-response handshakes, and manufacturing CA policy are not yet stable website-available implementation claims.",
+		"Separate what is available, integration-ready, and roadmap",
+		"<th scope=\"col\">Public status</th>",
+		"Available foundation",
+		"Integration-ready",
+		"Roadmap",
+		"Transfer, reset, and product readiness",
+	} {
+		if !strings.Contains(body, want) {
+			t.Fatalf("response does not contain %q: %s", want, body)
+		}
+	}
+}
+
 func TestFeaturePagesUseLocalVisualAssets(t *testing.T) {
 	handler := testServer(t, &memoryLeadStore{})
 
@@ -609,7 +642,7 @@ func TestFeaturePagesUseLocalVisualAssets(t *testing.T) {
 		{
 			path: "/features/provision",
 			src:  `/static/assets/feature-provision-flow.jpg`,
-			alt:  `alt="Provisioning dashboard with mobile pairing steps, QR onboarding, and device activation status cards."`,
+			alt:  `alt="Provisioning dashboard concept with mobile pairing steps, QR onboarding, and device activation status cards."`,
 		},
 		{
 			path: "/features/ota",

--- a/static/styles.css
+++ b/static/styles.css
@@ -1045,6 +1045,23 @@ p {
   min-width: 0;
 }
 
+.source-link {
+  margin: 18px 0 0;
+}
+
+.source-link a {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  color: var(--brand);
+  font-weight: 700;
+}
+
+.source-link .icon {
+  width: 18px;
+  height: 18px;
+}
+
 .feature-visual {
   min-width: 0;
   padding: 14px;

--- a/templates/feature.html
+++ b/templates/feature.html
@@ -6,6 +6,9 @@
       <p class="eyebrow">{{.Feature.Kicker}}</p>
       <h1>{{.Feature.Title}}</h1>
       <p>{{.Feature.Description}}</p>
+      {{if .Feature.SourceURL}}
+      <p class="source-link"><a href="{{.Feature.SourceURL}}" rel="noopener noreferrer"><span class="button-icon">{{icon "external"}}</span>{{.Feature.SourceLabel}}</a></p>
+      {{end}}
       <div class="hero-actions">
         <a class="button primary" href="{{localizedPath . "/contact"}}"><span class="button-icon">{{icon "mail"}}</span>{{t . "feature.discuss.prefix"}} {{.Feature.Title}}</a>
         <a class="button secondary" href="{{localizedPath . "/features"}}"><span class="button-icon">{{icon "grid"}}</span>{{t . "feature.all"}}</a>


### PR DESCRIPTION
## Summary
- revise the provisioning feature page to separate contract-backed cloud registry/activation from integration-ready claim material and roadmap local onboarding/readiness work
- add a contract source link to feature pages and document the provisioning availability boundary in the spec matrix
- update Traditional/Simplified Chinese provisioning copy plus route, content, and visual-smoke coverage

## Validation
- `go test ./internal/web -run 'TestProvisionFeatureAlignsPublicCopyWithContractStatus|TestFeaturePagesUseLocalVisualAssets|TestLocalizedFeatureRouteUsesLanguageMetadata'`
- `go test ./internal/content`
- `go test ./...`
- `go build ./cmd/server`
- `go run ./cmd/visual-smoke`

Refs #40