### PR TITLE
Guard OTA policy availability wording

### DIFF
--- a/internal/content/content_test.go
+++ b/internal/content/content_test.go
@@ -1,6 +1,11 @@
 package content
 
-import "testing"
+import (
+	"strings"
+	"testing"
+
+	"realtek-connect/internal/features"
+)
 
 func TestLocalizedCatalogsKeepFeatureAndDocSlugs(t *testing.T) {
 	en := CatalogFor(DefaultLocale())
@@ -29,6 +34,100 @@ func TestLocalizedCatalogsKeepFeatureAndDocSlugs(t *testing.T) {
 			}
 		}
 	}
+}
+
+func TestOTACopyKeepsCampaignPoliciesUnpromoted(t *testing.T) {
+	catalog := CatalogFor(DefaultLocale())
+	ota, ok := catalog.FeatureBySlug("ota")
+	if !ok {
+		t.Fatal("default catalog missing ota feature")
+	}
+
+	assertOTATableStatus(t, ota, "Scheduled policy", "Integration-ready contract")
+	assertOTATableStatus(t, ota, "Time-window policy", "Integration-ready contract")
+	assertOTATableStatus(t, ota, "User-consent policy", "Integration-ready contract")
+	assertOTATableStatus(t, ota, "Archive", "Roadmap campaign management")
+
+	copy := strings.Join([]string{
+		ota.Summary,
+		ota.Description,
+		strings.Join(ota.Highlights, " "),
+		strings.Join(ota.Capabilities, " "),
+	}, " ")
+	for _, want := range []string{
+		"available foundations",
+		"contract-defined follow-up work",
+		"integration-ready policy vocabulary",
+		"roadmap scope",
+	} {
+		if !strings.Contains(copy, want) {
+			t.Fatalf("OTA copy does not contain availability boundary %q: %s", want, copy)
+		}
+	}
+}
+
+func TestLocalizedOTACopyKeepsCampaignPoliciesUnpromoted(t *testing.T) {
+	tests := []struct {
+		localeCode string
+		wants      []string
+	}{
+		{
+			localeCode: "zh-TW",
+			wants:      []string{"現有基礎", "合約定義", "integration-ready policy vocabulary", "roadmap 範圍"},
+		},
+		{
+			localeCode: "zh-CN",
+			wants:      []string{"现有基础", "合约定義", "integration-ready policy vocabulary", "roadmap 範圍"},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.localeCode, func(t *testing.T) {
+			catalog := CatalogFor(localeByCode(t, tc.localeCode))
+			ota, ok := catalog.FeatureBySlug("ota")
+			if !ok {
+				t.Fatal("localized catalog missing ota feature")
+			}
+			copy := strings.Join([]string{
+				ota.Summary,
+				ota.Description,
+				strings.Join(ota.Highlights, " "),
+				strings.Join(ota.Capabilities, " "),
+			}, " ")
+			for _, want := range tc.wants {
+				if !strings.Contains(copy, want) {
+					t.Fatalf("%s OTA copy does not contain availability boundary %q: %s", tc.localeCode, want, copy)
+				}
+			}
+		})
+	}
+}
+
+func assertOTATableStatus(t *testing.T, feature features.Feature, concept, status string) {
+	t.Helper()
+
+	for _, row := range feature.Table.Rows {
+		if len(row.Cells) < 2 || row.Cells[0] != concept {
+			continue
+		}
+		if row.Cells[1] != status {
+			t.Fatalf("OTA table status for %q = %q, want %q", concept, row.Cells[1], status)
+		}
+		return
+	}
+	t.Fatalf("OTA table missing concept %q", concept)
+}
+
+func localeByCode(t *testing.T, code string) Locale {
+	t.Helper()
+
+	for _, locale := range SupportedLocales() {
+		if locale.Code == code {
+			return locale
+		}
+	}
+	t.Fatalf("missing supported locale %q", code)
+	return Locale{}
 }
 
 func TestLocaleFromPath(t *testing.T) {

--- a/internal/web/server_test.go
+++ b/internal/web/server_test.go
@@ -601,6 +601,36 @@ func TestOTAFeaturePageIncludesProductionDetail(t *testing.T) {
 	}
 }
 
+func TestOTAFeaturePageDoesNotPromoteCampaignPolicyScope(t *testing.T) {
+	handler := testServer(t, &memoryLeadStore{})
+
+	req := httptest.NewRequest(http.MethodGet, "/features/ota", nil)
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", rec.Code)
+	}
+
+	body := rec.Body.String()
+	assertTableRowStatus(t, body, "Scheduled policy", "Integration-ready contract")
+	assertTableRowStatus(t, body, "Time-window policy", "Integration-ready contract")
+	assertTableRowStatus(t, body, "User-consent policy", "Integration-ready contract")
+	assertTableRowStatus(t, body, "Archive", "Roadmap campaign management")
+
+	for _, tc := range []struct {
+		concept string
+		status  string
+	}{
+		{concept: "Scheduled policy", status: "Available foundation"},
+		{concept: "Time-window policy", status: "Available foundation"},
+		{concept: "User-consent policy", status: "Available foundation"},
+		{concept: "Archive", status: "Available foundation"},
+	} {
+		assertTableRowDoesNotHaveStatus(t, body, tc.concept, tc.status)
+	}
+}
+
 func TestProvisionFeatureAlignsPublicCopyWithContractStatus(t *testing.T) {
 	handler := testServer(t, &memoryLeadStore{})
 
@@ -632,6 +662,42 @@ func TestProvisionFeatureAlignsPublicCopyWithContractStatus(t *testing.T) {
 			t.Fatalf("response does not contain %q: %s", want, body)
 		}
 	}
+}
+
+func assertTableRowStatus(t *testing.T, body, concept, status string) {
+	t.Helper()
+
+	row := tableRowForConcept(t, body, concept)
+	want := "<td>" + status + "</td>"
+	if !strings.Contains(row, want) {
+		t.Fatalf("table row for %q does not contain status %q: %s", concept, status, row)
+	}
+}
+
+func assertTableRowDoesNotHaveStatus(t *testing.T, body, concept, status string) {
+	t.Helper()
+
+	row := tableRowForConcept(t, body, concept)
+	forbidden := "<td>" + status + "</td>"
+	if strings.Contains(row, forbidden) {
+		t.Fatalf("table row for %q unexpectedly contains status %q: %s", concept, status, row)
+	}
+}
+
+func tableRowForConcept(t *testing.T, body, concept string) string {
+	t.Helper()
+
+	cell := "<td>" + concept + "</td>"
+	index := strings.Index(body, cell)
+	if index < 0 {
+		t.Fatalf("response does not contain table concept %q: %s", concept, body)
+	}
+	start := strings.LastIndex(body[:index], "<tr>")
+	end := strings.Index(body[index:], "</tr>")
+	if start < 0 || end < 0 {
+		t.Fatalf("response does not contain a complete table row for %q: %s", concept, body)
+	}
+	return body[start : index+end+len("</tr>")]
 }
 
 func TestFeaturePagesUseLocalVisualAssets(t *testing.T) {


### PR DESCRIPTION
## Summary
- add catalog-level regression coverage that keeps OTA campaign policy copy in available, integration-ready, and roadmap buckets
- add rendered `/features/ota` table assertions so scheduled, time-window, user-consent, and archive rows cannot be promoted to available foundation prematurely
- keep current public wording unchanged until backend and SDK follow-up issues land

## Validation
- `go test ./internal/content`
- `go test ./internal/web -run 'TestOTAFeaturePageIncludesProductionDetail|TestOTAFeaturePageDoesNotPromoteCampaignPolicyScope|TestFeatureMetadataUsesFeatureSummary|TestLocalizedFeatureRouteUsesLanguageMetadata'`
- `go test ./...`
- `go build ./cmd/server`
- `go run ./cmd/visual-smoke`

Refs #44