### PR TITLE
[Analytics] Add configuration and SQLite storage foundation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,6 @@ bin/
 /server
 data/*.db
 data/*.db-*
+data/analytics.db
+data/analytics.db-*
 .DS_Store

--- a/README.md
+++ b/README.md
@@ -40,6 +40,9 @@ Environment variables:
 
 - `PORT`: HTTP port, default `8080`.
 - `DATABASE_PATH`: SQLite database path, default `data/connectplus.db`.
+- `ANALYTICS_ENABLED`: analytics toggle, default `true`.
+- `ANALYTICS_DATABASE_PATH`: SQLite analytics database path, default `data/analytics.db`.
+- `ANALYTICS_RETENTION_DAYS`: raw analytics retention window, default `90`.
 - `ADMIN_TOKEN`: enables protected lead viewing and CSV export.
 - `DISABLE_SEARCH_INDEXING`: set to `true` on private/test deployments to emit `X-Robots-Tag: noindex, nofollow, noarchive`, add page-level `robots` meta tags, disallow all crawling in `/robots.txt`, and hide `/sitemap.xml`.
 - `PUBLIC_BASE_URL`: optional public origin such as `https://webtest.mgmeet.io`. When empty, canonical URLs, social image URLs, `hreflang`, robots sitemap references, and sitemap locations are built from the incoming request host and forwarded headers.
@@ -151,5 +154,6 @@ docker run --rm -p 8080:8080 \
 Deployment notes:
 
 - The image keeps application state only in SQLite under `/data/connectplus.db`; mount `/data` to persist leads across restarts.
+- When analytics is enabled, the app also keeps first-party event data in `/data/analytics.db`.
 - The container serves HTTP on port `8080`. Production TLS termination should be handled by a reverse proxy, ingress, or deployment platform in front of the app.
 - Native builds remain supported for environments that prefer `go build` over containers.

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -13,6 +13,7 @@ import (
 	"syscall"
 	"time"
 
+	"realtek-connect/internal/analytics"
 	"realtek-connect/internal/leads"
 	"realtek-connect/internal/web"
 
@@ -54,6 +55,14 @@ func run(ctx context.Context, logger *log.Logger) error {
 	repository := leads.NewRepository(db)
 	if err := repository.Init(); err != nil {
 		return err
+	}
+
+	analyticsStore, err := analytics.Open(ctx, analytics.ConfigFromEnv())
+	if err != nil {
+		return err
+	}
+	if analyticsStore != nil {
+		defer analyticsStore.Close()
 	}
 
 	application, err := web.NewServer(web.Config{

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -267,6 +267,9 @@ Environment:
 
 - `PORT`, default `8080`.
 - `DATABASE_PATH`, default `data/connectplus.db`.
+- `ANALYTICS_ENABLED`, optional and enabled by default. When false-like, analytics database setup is skipped until the later event-ingestion work lands.
+- `ANALYTICS_DATABASE_PATH`, optional and default `data/analytics.db`.
+- `ANALYTICS_RETENTION_DAYS`, optional and default `90`.
 - `ADMIN_TOKEN`, optional. When set, enables protected lead review and CSV export.
 - `DISABLE_SEARCH_INDEXING`, optional. When truthy, marks the site as non-indexable with HTTP `X-Robots-Tag`, page-level robots meta tags, `/robots.txt` `Disallow: /`, and a disabled `/sitemap.xml`.
 - `PUBLIC_BASE_URL`, optional. When empty, canonical URLs, social image URLs, `hreflang` alternates, robots sitemap references, and sitemap locations are generated from the incoming request host and forwarded headers. When set, generated public absolute URLs use this fixed base URL.
@@ -306,6 +309,8 @@ Commands:
 
 SQLite stores website leads only. It does not store real IoT telemetry or device state.
 
+When analytics is enabled, first-party event telemetry uses a separate SQLite database so raw analytics data stays isolated from lead data.
+
 Default database path:
 
 ```text
@@ -316,6 +321,18 @@ Container default database path:
 
 ```text
 /data/connectplus.db
+```
+
+Default analytics database path:
+
+```text
+data/analytics.db
+```
+
+Container default analytics database path:
+
+```text
+/data/analytics.db
 ```
 
 Container deployment notes:
@@ -336,6 +353,30 @@ CREATE TABLE IF NOT EXISTS leads (
   message TEXT,
   created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP
 );
+```
+
+Analytics schema:
+
+```sql
+CREATE TABLE IF NOT EXISTS analytics_events (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  ts INTEGER NOT NULL,
+  event TEXT NOT NULL,
+  page TEXT NOT NULL,
+  cta TEXT,
+  percent INTEGER,
+  duration INTEGER,
+  variant TEXT,
+  referrer_origin TEXT,
+  session_id TEXT,
+  created_at TEXT NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_analytics_events_ts
+  ON analytics_events(ts);
+
+CREATE INDEX IF NOT EXISTS idx_analytics_events_event_page
+  ON analytics_events(event, page);
 ```
 
 Contact form fields:

--- a/internal/analytics/config.go
+++ b/internal/analytics/config.go
@@ -1,0 +1,55 @@
+package analytics
+
+import (
+	"os"
+	"strconv"
+	"strings"
+)
+
+const (
+	DefaultDatabasePath  = "data/analytics.db"
+	DefaultRetentionDays = 90
+)
+
+type Config struct {
+	Enabled       bool
+	DatabasePath  string
+	RetentionDays int
+}
+
+func DefaultConfig() Config {
+	return Config{
+		Enabled:       true,
+		DatabasePath:  DefaultDatabasePath,
+		RetentionDays: DefaultRetentionDays,
+	}
+}
+
+func ConfigFromEnv() Config {
+	cfg := DefaultConfig()
+
+	if value, ok := os.LookupEnv("ANALYTICS_ENABLED"); ok {
+		cfg.Enabled = parseEnabled(value)
+	}
+
+	if value := strings.TrimSpace(os.Getenv("ANALYTICS_DATABASE_PATH")); value != "" {
+		cfg.DatabasePath = value
+	}
+
+	if value := strings.TrimSpace(os.Getenv("ANALYTICS_RETENTION_DAYS")); value != "" {
+		if days, err := strconv.Atoi(value); err == nil && days > 0 {
+			cfg.RetentionDays = days
+		}
+	}
+
+	return cfg
+}
+
+func parseEnabled(value string) bool {
+	switch strings.ToLower(strings.TrimSpace(value)) {
+	case "0", "false", "no", "off":
+		return false
+	default:
+		return true
+	}
+}

--- a/internal/analytics/config_test.go
+++ b/internal/analytics/config_test.go
@@ -1,0 +1,35 @@
+package analytics
+
+import "testing"
+
+func TestDefaultConfig(t *testing.T) {
+	cfg := DefaultConfig()
+
+	if !cfg.Enabled {
+		t.Fatal("enabled = false, want true")
+	}
+	if cfg.DatabasePath != DefaultDatabasePath {
+		t.Fatalf("database path = %q, want %q", cfg.DatabasePath, DefaultDatabasePath)
+	}
+	if cfg.RetentionDays != DefaultRetentionDays {
+		t.Fatalf("retention days = %d, want %d", cfg.RetentionDays, DefaultRetentionDays)
+	}
+}
+
+func TestConfigFromEnvAppliesOverrides(t *testing.T) {
+	t.Setenv("ANALYTICS_ENABLED", "off")
+	t.Setenv("ANALYTICS_DATABASE_PATH", "tmp/analytics.db")
+	t.Setenv("ANALYTICS_RETENTION_DAYS", "14")
+
+	cfg := ConfigFromEnv()
+
+	if cfg.Enabled {
+		t.Fatal("enabled = true, want false")
+	}
+	if cfg.DatabasePath != "tmp/analytics.db" {
+		t.Fatalf("database path = %q, want tmp/analytics.db", cfg.DatabasePath)
+	}
+	if cfg.RetentionDays != 14 {
+		t.Fatalf("retention days = %d, want 14", cfg.RetentionDays)
+	}
+}

--- a/internal/analytics/repository.go
+++ b/internal/analytics/repository.go
@@ -1,0 +1,100 @@
+package analytics
+
+import (
+	"context"
+	"database/sql"
+	"os"
+	"path/filepath"
+)
+
+type Repository struct {
+	db            *sql.DB
+	retentionDays int
+}
+
+func Open(ctx context.Context, cfg Config) (*Repository, error) {
+	if !cfg.Enabled {
+		return nil, nil
+	}
+
+	if cfg.DatabasePath == "" {
+		cfg.DatabasePath = DefaultDatabasePath
+	}
+	if cfg.RetentionDays <= 0 {
+		cfg.RetentionDays = DefaultRetentionDays
+	}
+
+	if err := os.MkdirAll(filepath.Dir(cfg.DatabasePath), 0o755); err != nil {
+		return nil, err
+	}
+
+	db, err := sql.Open("sqlite", cfg.DatabasePath)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := db.PingContext(ctx); err != nil {
+		_ = db.Close()
+		return nil, err
+	}
+
+	repository := &Repository{
+		db:            db,
+		retentionDays: cfg.RetentionDays,
+	}
+	if err := repository.Init(); err != nil {
+		_ = db.Close()
+		return nil, err
+	}
+
+	return repository, nil
+}
+
+func NewRepository(db *sql.DB, retentionDays int) *Repository {
+	if retentionDays <= 0 {
+		retentionDays = DefaultRetentionDays
+	}
+	return &Repository{
+		db:            db,
+		retentionDays: retentionDays,
+	}
+}
+
+func (r *Repository) Close() error {
+	if r == nil || r.db == nil {
+		return nil
+	}
+	return r.db.Close()
+}
+
+func (r *Repository) RetentionDays() int {
+	if r == nil {
+		return 0
+	}
+	return r.retentionDays
+}
+
+func (r *Repository) Init() error {
+	_, err := r.db.Exec(`
+CREATE TABLE IF NOT EXISTS analytics_events (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  ts INTEGER NOT NULL,
+  event TEXT NOT NULL,
+  page TEXT NOT NULL,
+  cta TEXT,
+  percent INTEGER,
+  duration INTEGER,
+  variant TEXT,
+  referrer_origin TEXT,
+  session_id TEXT,
+  created_at TEXT NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_analytics_events_ts
+  ON analytics_events(ts);
+
+CREATE INDEX IF NOT EXISTS idx_analytics_events_event_page
+  ON analytics_events(event, page);
+`)
+	return err
+}

--- a/internal/analytics/repository.go
+++ b/internal/analytics/repository.go
@@ -5,6 +5,8 @@ import (
 	"database/sql"
 	"os"
 	"path/filepath"
+
+	_ "modernc.org/sqlite"
 )
 
 type Repository struct {

--- a/internal/analytics/repository_test.go
+++ b/internal/analytics/repository_test.go
@@ -1,0 +1,77 @@
+package analytics
+
+import (
+	"context"
+	"database/sql"
+	"os"
+	"path/filepath"
+	"testing"
+
+	_ "modernc.org/sqlite"
+)
+
+func TestOpenInitializesSQLiteSchema(t *testing.T) {
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "analytics.db")
+
+	repository, err := Open(context.Background(), func() Config {
+		cfg := DefaultConfig()
+		cfg.DatabasePath = dbPath
+		return cfg
+	}())
+	if err != nil {
+		t.Fatalf("open analytics store: %v", err)
+	}
+	defer repository.Close()
+
+	if _, err := os.Stat(dbPath); err != nil {
+		t.Fatalf("analytics database file was not created: %v", err)
+	}
+
+	db, err := sql.Open("sqlite", dbPath)
+	if err != nil {
+		t.Fatalf("open sqlite: %v", err)
+	}
+	defer db.Close()
+
+	for _, name := range []string{
+		"analytics_events",
+		"idx_analytics_events_ts",
+		"idx_analytics_events_event_page",
+	} {
+		var count int
+		if err := db.QueryRowContext(context.Background(), `
+SELECT COUNT(*)
+FROM sqlite_master
+WHERE name = ?`, name).Scan(&count); err != nil {
+			t.Fatalf("lookup %s: %v", name, err)
+		}
+		if count != 1 {
+			t.Fatalf("sqlite object %q not initialized", name)
+		}
+	}
+
+	if got := repository.RetentionDays(); got != DefaultRetentionDays {
+		t.Fatalf("retention days = %d, want %d", got, DefaultRetentionDays)
+	}
+}
+
+func TestOpenDisabledSkipsStorageInitialization(t *testing.T) {
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "analytics.db")
+
+	repository, err := Open(context.Background(), Config{
+		Enabled:      false,
+		DatabasePath: dbPath,
+	})
+	if err != nil {
+		t.Fatalf("open disabled analytics store: %v", err)
+	}
+	if repository != nil {
+		t.Fatal("repository = non-nil, want nil when analytics is disabled")
+	}
+
+	if _, err := os.Stat(dbPath); !os.IsNotExist(err) {
+		t.Fatalf("analytics database file exists when disabled: %v", err)
+	}
+}

--- a/internal/analytics/repository_test.go
+++ b/internal/analytics/repository_test.go
@@ -7,7 +7,7 @@ import (
 	"path/filepath"
 	"testing"
 
-	_ "modernc.org/sqlite"
+	"realtek-connect/internal/leads"
 )
 
 func TestOpenInitializesSQLiteSchema(t *testing.T) {
@@ -74,4 +74,78 @@ func TestOpenDisabledSkipsStorageInitialization(t *testing.T) {
 	if _, err := os.Stat(dbPath); !os.IsNotExist(err) {
 		t.Fatalf("analytics database file exists when disabled: %v", err)
 	}
+}
+
+func TestAnalyticsStorageIsSeparateFromLeadStorage(t *testing.T) {
+	dir := t.TempDir()
+	leadPath := filepath.Join(dir, "connectplus.db")
+	analyticsPath := filepath.Join(dir, "analytics.db")
+
+	leadDB, err := sql.Open("sqlite", leadPath)
+	if err != nil {
+		t.Fatalf("open lead sqlite: %v", err)
+	}
+	defer leadDB.Close()
+
+	leadRepository := leads.NewRepository(leadDB)
+	if err := leadRepository.Init(); err != nil {
+		t.Fatalf("initialize lead schema: %v", err)
+	}
+	if err := leadRepository.Insert(context.Background(), leads.Lead{
+		Name:     "Ada",
+		Company:  "Example",
+		Email:    "ada@example.com",
+		Interest: "ota",
+		Message:  "Please follow up.",
+	}); err != nil {
+		t.Fatalf("insert lead: %v", err)
+	}
+
+	analyticsRepository, err := Open(context.Background(), Config{
+		Enabled:      true,
+		DatabasePath: analyticsPath,
+	})
+	if err != nil {
+		t.Fatalf("open analytics store: %v", err)
+	}
+	defer analyticsRepository.Close()
+
+	assertSQLiteObjectExists(t, leadDB, "leads")
+	assertSQLiteObjectMissing(t, leadDB, "analytics_events")
+
+	analyticsDB, err := sql.Open("sqlite", analyticsPath)
+	if err != nil {
+		t.Fatalf("open analytics sqlite: %v", err)
+	}
+	defer analyticsDB.Close()
+
+	assertSQLiteObjectExists(t, analyticsDB, "analytics_events")
+	assertSQLiteObjectMissing(t, analyticsDB, "leads")
+}
+
+func assertSQLiteObjectExists(t *testing.T, db *sql.DB, name string) {
+	t.Helper()
+	if countSQLiteObjects(t, db, name) != 1 {
+		t.Fatalf("sqlite object %q not initialized", name)
+	}
+}
+
+func assertSQLiteObjectMissing(t *testing.T, db *sql.DB, name string) {
+	t.Helper()
+	if countSQLiteObjects(t, db, name) != 0 {
+		t.Fatalf("sqlite object %q should not exist", name)
+	}
+}
+
+func countSQLiteObjects(t *testing.T, db *sql.DB, name string) int {
+	t.Helper()
+
+	var count int
+	if err := db.QueryRowContext(context.Background(), `
+SELECT COUNT(*)
+FROM sqlite_master
+WHERE name = ?`, name).Scan(&count); err != nil {
+		t.Fatalf("lookup %s: %v", name, err)
+	}
+	return count
 }


### PR DESCRIPTION
Refs #46

## Summary
- Add analytics runtime config defaults for `ANALYTICS_ENABLED`, `ANALYTICS_DATABASE_PATH`, and `ANALYTICS_RETENTION_DAYS`.
- Initialize a separate `analytics_events` SQLite database with the spec indexes at startup.
- Document the new analytics storage path and env vars.
- Explicitly ignore `data/analytics.db` in git.

## Validation
- `go test ./internal/analytics ./cmd/server ./internal/leads`
- `go test ./...`