### PR TITLE
[CI] Fix CD writable data directory

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -66,16 +66,19 @@ jobs:
         shell: bash
         run: |
           rm -rf dist
-          mkdir -p dist/bin
+          mkdir -p dist/bin dist/data
+          chmod 0777 dist/data
           GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -o dist/bin/realtek-connect ./cmd/server
           cp -R templates static dist/
           test -x dist/bin/realtek-connect
+          test -d dist/data
+          test -w dist/data
 
       - name: Deploy on website test host
         shell: bash
         run: |
           test -x /usr/local/sbin/deploy-realtek-connect
-          tar -C dist -czf - bin templates static | sudo /usr/local/sbin/deploy-realtek-connect
+          tar -C dist -czf - bin templates static data | sudo /usr/local/sbin/deploy-realtek-connect
 
       - name: Verify public deployment
         shell: bash

--- a/README.md
+++ b/README.md
@@ -155,5 +155,6 @@ Deployment notes:
 
 - The image keeps application state only in SQLite under `/data/connectplus.db`; mount `/data` to persist leads across restarts.
 - When analytics is enabled, the app also keeps first-party event data in `/data/analytics.db`.
+- The native CD bundle includes a writable `data/` directory for test-host defaults. Production native deployments should still set `DATABASE_PATH` and `ANALYTICS_DATABASE_PATH` to a persistent service-owned directory.
 - The container serves HTTP on port `8080`. Production TLS termination should be handled by a reverse proxy, ingress, or deployment platform in front of the app.
 - Native builds remain supported for environments that prefer `go build` over containers.

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -338,6 +338,7 @@ Container default analytics database path:
 Container deployment notes:
 
 - `Dockerfile` copies the compiled server together with `templates/` and `static/`, which are runtime dependencies for page rendering and asset delivery.
+- The native CD bundle includes an empty writable `data/` directory so default `data/connectplus.db` and `data/analytics.db` paths can initialize on the website test host. Production native hosts should set `DATABASE_PATH` and `ANALYTICS_DATABASE_PATH` to persistent service-owned storage.
 - `/data` is declared as the persistent volume for SQLite-backed lead storage.
 - HTTPS is intentionally out of process and should be handled by the reverse proxy or deployment platform instead of the Go app directly.
 


### PR DESCRIPTION
Refs #56

## Summary
- Include a writable `data/` directory in the native CD deployment bundle.
- Add bundle checks so the directory is present and writable before deploying.
- Document that the test-host bundle supports default `data/*.db` paths while production native hosts should use persistent service-owned paths.

## Failure
- Main CD run https://github.com/hkt999rtk/rtk_cloud_frontend/actions/runs/25247624703 failed after the service restarted with `server exited with error: mkdir data: permission denied`.
- The later main CD run https://github.com/hkt999rtk/rtk_cloud_frontend/actions/runs/25247678677 failed the same way.

## Validation
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/cd.yml"); puts "cd yaml ok"'`
- local CD bundle build command including `dist/data` creation and archive listing
- `go test ./...`
- `git diff --check`
