### PR TITLE
[CI] Finish analytics data path deployment fix

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -78,7 +78,43 @@ jobs:
         shell: bash
         run: |
           test -x /usr/local/sbin/deploy-realtek-connect
+          set +e
           tar -C dist -czf - bin templates static data | sudo /usr/local/sbin/deploy-realtek-connect
+          deploy_status=$?
+          set -e
+
+          if [ "$deploy_status" -eq 0 ]; then
+            exit 0
+          fi
+
+          service_name="realtek-connect.service"
+          recent_logs="$(sudo journalctl -u "$service_name" -n 80 --no-pager || true)"
+          echo "$recent_logs"
+          if ! grep -E "mkdir data: permission denied|unable to open database file" <<<"$recent_logs"; then
+            exit "$deploy_status"
+          fi
+
+          working_dir="$(systemctl show "$service_name" --property=WorkingDirectory --value)"
+          service_user="$(systemctl show "$service_name" --property=User --value)"
+          service_group="$(systemctl show "$service_name" --property=Group --value)"
+
+          if [ -n "$working_dir" ] && [ "$working_dir" != "/" ] && [ -n "$service_user" ]; then
+            if [ -z "$service_group" ]; then
+              service_group="$service_user"
+            fi
+
+            sudo install -d -o "$service_user" -g "$service_group" -m 0750 "$working_dir/data"
+            sudo systemctl restart "$service_name"
+
+            for _ in $(seq 1 20); do
+              if curl -k -fsS --max-time 5 http://127.0.0.1/healthz; then
+                exit 0
+              fi
+              sleep 0.5
+            done
+          fi
+
+          exit "$deploy_status"
 
       - name: Verify public deployment
         shell: bash

--- a/Dockerfile
+++ b/Dockerfile
@@ -26,6 +26,7 @@ COPY --from=builder /src/static /app/static
 
 ENV PORT=8080
 ENV DATABASE_PATH=/data/connectplus.db
+ENV ANALYTICS_DATABASE_PATH=/data/analytics.db
 
 VOLUME ["/data"]
 EXPOSE 8080

--- a/cmd/server/main_test.go
+++ b/cmd/server/main_test.go
@@ -6,6 +6,8 @@ import (
 	"io"
 	"log"
 	"net/http"
+	"os"
+	"strings"
 	"testing"
 	"time"
 )
@@ -83,5 +85,22 @@ func TestServeWithGracefulShutdownReturnsListenErrors(t *testing.T) {
 		}
 	case <-time.After(2 * time.Second):
 		t.Fatal("serveWithGracefulShutdown did not return")
+	}
+}
+
+func TestDockerfileUsesPersistentSQLitePaths(t *testing.T) {
+	contents, err := os.ReadFile("../../Dockerfile")
+	if err != nil {
+		t.Fatalf("read Dockerfile: %v", err)
+	}
+
+	text := string(contents)
+	for _, expected := range []string{
+		"ENV DATABASE_PATH=/data/connectplus.db",
+		"ENV ANALYTICS_DATABASE_PATH=/data/analytics.db",
+	} {
+		if !strings.Contains(text, expected) {
+			t.Fatalf("Dockerfile missing %q", expected)
+		}
 	}
 }

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -339,7 +339,7 @@ Container deployment notes:
 
 - `Dockerfile` copies the compiled server together with `templates/` and `static/`, which are runtime dependencies for page rendering and asset delivery.
 - The native CD bundle includes an empty writable `data/` directory so default `data/connectplus.db` and `data/analytics.db` paths can initialize on the website test host. Production native hosts should set `DATABASE_PATH` and `ANALYTICS_DATABASE_PATH` to persistent service-owned storage.
-- `/data` is declared as the persistent volume for SQLite-backed lead storage.
+- `/data` is declared as the persistent volume for SQLite-backed lead and analytics storage.
 - HTTPS is intentionally out of process and should be handled by the reverse proxy or deployment platform instead of the Go app directly.
 
 Schema:


### PR DESCRIPTION
Refs #56

## Summary
- Set the Docker analytics database path to `/data/analytics.db` so container storage matches the documented persistent volume.
- Add a regression test that asserts Docker SQLite defaults use `/data` for both lead and analytics databases.
- Harden CD deploy fallback for the website test host by repairing the service-owned `data/` directory only when the journal shows the known SQLite data-dir startup failure, then restarting and requiring local health to recover.
- Align SPEC wording so `/data` is documented for both lead and analytics SQLite storage.

## Failure
- PR #59 fixed the missing `data/` directory, but the merged main CD run still failed in deploy: https://github.com/hkt999rtk/rtk_cloud_frontend/actions/runs/25247775669
- The failure advanced from `mkdir data: permission denied` to SQLite open failures after the deploy helper unpacked `data/` without usable service ownership.
- PR #59 also had a review note that Dockerfile still lacked `ANALYTICS_DATABASE_PATH=/data/analytics.db`.

## Validation
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/cd.yml"); puts "cd yaml ok"'`
- `go test ./cmd/server -run TestDockerfileUsesPersistentSQLitePaths -count=1`
- `go test ./...`
- `git diff --check`
