### PR TITLE
[CI] Package deploy data with service ownership

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -78,8 +78,23 @@ jobs:
         shell: bash
         run: |
           test -x /usr/local/sbin/deploy-realtek-connect
+          service_name="realtek-connect.service"
+          service_user="$(systemctl show "$service_name" --property=User --value)"
+          service_group="$(systemctl show "$service_name" --property=Group --value)"
+          tar_owner_args=()
+          if [ -n "$service_user" ]; then
+            if [ -z "$service_group" ]; then
+              service_group="$service_user"
+            fi
+            tar_owner_args=(
+              --owner="$service_user"
+              --group="$service_group"
+              --mode=u+rwX,go-rwx
+            )
+          fi
+
           set +e
-          tar -C dist -czf - bin templates static data | sudo /usr/local/sbin/deploy-realtek-connect
+          tar "${tar_owner_args[@]}" -C dist -czf - bin templates static data | sudo /usr/local/sbin/deploy-realtek-connect
           deploy_status=$?
           set -e
 
@@ -87,33 +102,8 @@ jobs:
             exit 0
           fi
 
-          service_name="realtek-connect.service"
           recent_logs="$(sudo journalctl -u "$service_name" -n 80 --no-pager || true)"
           echo "$recent_logs"
-          if ! grep -E "mkdir data: permission denied|unable to open database file" <<<"$recent_logs"; then
-            exit "$deploy_status"
-          fi
-
-          working_dir="$(systemctl show "$service_name" --property=WorkingDirectory --value)"
-          service_user="$(systemctl show "$service_name" --property=User --value)"
-          service_group="$(systemctl show "$service_name" --property=Group --value)"
-
-          if [ -n "$working_dir" ] && [ "$working_dir" != "/" ] && [ -n "$service_user" ]; then
-            if [ -z "$service_group" ]; then
-              service_group="$service_user"
-            fi
-
-            sudo install -d -o "$service_user" -g "$service_group" -m 0750 "$working_dir/data"
-            sudo systemctl restart "$service_name"
-
-            for _ in $(seq 1 20); do
-              if curl -k -fsS --max-time 5 http://127.0.0.1/healthz; then
-                exit 0
-              fi
-              sleep 0.5
-            done
-          fi
-
           exit "$deploy_status"
 
       - name: Verify public deployment

--- a/cmd/server/main_test.go
+++ b/cmd/server/main_test.go
@@ -104,3 +104,24 @@ func TestDockerfileUsesPersistentSQLitePaths(t *testing.T) {
 		}
 	}
 }
+
+func TestCDWorkflowPackagesDataForServiceUser(t *testing.T) {
+	contents, err := os.ReadFile("../../.github/workflows/cd.yml")
+	if err != nil {
+		t.Fatalf("read cd workflow: %v", err)
+	}
+
+	text := string(contents)
+	for _, expected := range []string{
+		`service_user="$(systemctl show "$service_name" --property=User --value)"`,
+		`service_group="$(systemctl show "$service_name" --property=Group --value)"`,
+		`--owner="$service_user"`,
+		`--group="$service_group"`,
+		`--mode=u+rwX,go-rwx`,
+		`tar "${tar_owner_args[@]}" -C dist -czf - bin templates static data | sudo /usr/local/sbin/deploy-realtek-connect`,
+	} {
+		if !strings.Contains(text, expected) {
+			t.Fatalf("cd workflow missing %q", expected)
+		}
+	}
+}


### PR DESCRIPTION
Refs #56

## Summary
- Read the systemd service user/group before packaging the CD bundle.
- Store service ownership and restrictive writable directory modes in the deployment archive so `data/` extracts as writable by the service on the first deploy attempt.
- Remove the unsupported interactive `sudo install` recovery path and keep failure logs for diagnostics.
- Add regression coverage for the CD archive ownership guard.

## Failure
- Main CD after PR #61 still failed: https://github.com/hkt999rtk/rtk_cloud_frontend/actions/runs/25247878292
- The workflow detected the SQLite open failure, but the fallback repair attempted `sudo install` and hit an interactive password prompt on the self-hosted runner.

## Validation
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/cd.yml"); puts "cd yaml ok"'`
- `go test ./cmd/server -run 'TestDockerfileUsesPersistentSQLitePaths|TestCDWorkflowPackagesDataForServiceUser' -count=1`
- `go test ./...`
- `git diff --check`