### PR TITLE
[Analytics] Add raw event retention cleanup

### DIFF
--- a/internal/analytics/repository.go
+++ b/internal/analytics/repository.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	"os"
 	"path/filepath"
+	"time"
 
 	_ "modernc.org/sqlite"
 )
@@ -45,6 +46,10 @@ func Open(ctx context.Context, cfg Config) (*Repository, error) {
 		retentionDays: cfg.RetentionDays,
 	}
 	if err := repository.Init(); err != nil {
+		_ = db.Close()
+		return nil, err
+	}
+	if _, err := repository.CleanupExpiredEvents(ctx, time.Now().UTC()); err != nil {
 		_ = db.Close()
 		return nil, err
 	}
@@ -99,4 +104,24 @@ CREATE INDEX IF NOT EXISTS idx_analytics_events_event_page
   ON analytics_events(event, page);
 `)
 	return err
+}
+
+func (r *Repository) CleanupExpiredEvents(ctx context.Context, now time.Time) (int64, error) {
+	if r == nil || r.db == nil {
+		return 0, nil
+	}
+	if r.retentionDays <= 0 {
+		return 0, nil
+	}
+
+	cutoff := now.UTC().Add(-time.Duration(r.retentionDays) * 24 * time.Hour).Unix()
+	result, err := r.db.ExecContext(ctx, `DELETE FROM analytics_events WHERE ts < ?`, cutoff)
+	if err != nil {
+		return 0, err
+	}
+	rowsAffected, err := result.RowsAffected()
+	if err != nil {
+		return 0, err
+	}
+	return rowsAffected, nil
 }

--- a/internal/analytics/repository_test.go
+++ b/internal/analytics/repository_test.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"realtek-connect/internal/leads"
 )
@@ -123,6 +124,147 @@ func TestAnalyticsStorageIsSeparateFromLeadStorage(t *testing.T) {
 	assertSQLiteObjectMissing(t, analyticsDB, "leads")
 }
 
+func TestCleanupExpiredEventsUsesDefaultRetention(t *testing.T) {
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "analytics.db")
+
+	db, err := sql.Open("sqlite", dbPath)
+	if err != nil {
+		t.Fatalf("open sqlite: %v", err)
+	}
+	defer db.Close()
+
+	repository := NewRepository(db, 0)
+	if err := repository.Init(); err != nil {
+		t.Fatalf("initialize analytics schema: %v", err)
+	}
+
+	asOf := time.Date(2026, 5, 5, 12, 0, 0, 0, time.UTC)
+	cutoff := asOf.Add(-DefaultRetentionDays * 24 * time.Hour).Unix()
+
+	seedAnalyticsEvent(t, db, cutoff-1)
+	seedAnalyticsEvent(t, db, cutoff)
+	seedAnalyticsEvent(t, db, cutoff+1)
+
+	deleted, err := repository.CleanupExpiredEvents(context.Background(), asOf)
+	if err != nil {
+		t.Fatalf("cleanup expired events: %v", err)
+	}
+	if deleted != 1 {
+		t.Fatalf("deleted rows = %d, want 1", deleted)
+	}
+
+	assertAnalyticsEventTimestamps(t, db, cutoff, cutoff+1)
+}
+
+func TestCleanupExpiredEventsUsesCustomRetention(t *testing.T) {
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "analytics.db")
+
+	db, err := sql.Open("sqlite", dbPath)
+	if err != nil {
+		t.Fatalf("open sqlite: %v", err)
+	}
+	defer db.Close()
+
+	repository := NewRepository(db, 14)
+	if err := repository.Init(); err != nil {
+		t.Fatalf("initialize analytics schema: %v", err)
+	}
+
+	asOf := time.Date(2026, 5, 5, 12, 0, 0, 0, time.UTC)
+	cutoff := asOf.Add(-14 * 24 * time.Hour).Unix()
+
+	seedAnalyticsEvent(t, db, cutoff-86400)
+	seedAnalyticsEvent(t, db, cutoff)
+	seedAnalyticsEvent(t, db, cutoff+86400)
+
+	deleted, err := repository.CleanupExpiredEvents(context.Background(), asOf)
+	if err != nil {
+		t.Fatalf("cleanup expired events: %v", err)
+	}
+	if deleted != 1 {
+		t.Fatalf("deleted rows = %d, want 1", deleted)
+	}
+
+	assertAnalyticsEventTimestamps(t, db, cutoff, cutoff+86400)
+}
+
+func TestCleanupExpiredEventsPreservesBoundaryTimestamp(t *testing.T) {
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "analytics.db")
+
+	db, err := sql.Open("sqlite", dbPath)
+	if err != nil {
+		t.Fatalf("open sqlite: %v", err)
+	}
+	defer db.Close()
+
+	repository := NewRepository(db, DefaultRetentionDays)
+	if err := repository.Init(); err != nil {
+		t.Fatalf("initialize analytics schema: %v", err)
+	}
+
+	asOf := time.Date(2026, 5, 5, 12, 0, 0, 0, time.UTC)
+	boundary := asOf.Add(-DefaultRetentionDays * 24 * time.Hour).Unix()
+
+	seedAnalyticsEvent(t, db, boundary)
+
+	deleted, err := repository.CleanupExpiredEvents(context.Background(), asOf)
+	if err != nil {
+		t.Fatalf("cleanup expired events: %v", err)
+	}
+	if deleted != 0 {
+		t.Fatalf("deleted rows = %d, want 0", deleted)
+	}
+
+	assertAnalyticsEventTimestamps(t, db, boundary)
+}
+
+func TestOpenCleansExpiredEventsOnStartup(t *testing.T) {
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "analytics.db")
+
+	db, err := sql.Open("sqlite", dbPath)
+	if err != nil {
+		t.Fatalf("open sqlite: %v", err)
+	}
+
+	repository := NewRepository(db, DefaultRetentionDays)
+	if err := repository.Init(); err != nil {
+		_ = db.Close()
+		t.Fatalf("initialize analytics schema: %v", err)
+	}
+
+	now := time.Now().UTC()
+	seedAnalyticsEvent(t, db, now.Add(-91*24*time.Hour).Unix())
+	seedAnalyticsEvent(t, db, now.Add(-89*24*time.Hour).Unix())
+
+	if err := db.Close(); err != nil {
+		t.Fatalf("close seeded sqlite: %v", err)
+	}
+
+	reopened, err := Open(context.Background(), Config{
+		Enabled:       true,
+		DatabasePath:  dbPath,
+		RetentionDays: DefaultRetentionDays,
+	})
+	if err != nil {
+		t.Fatalf("reopen analytics store: %v", err)
+	}
+	defer reopened.Close()
+
+	verifyDB, err := sql.Open("sqlite", dbPath)
+	if err != nil {
+		t.Fatalf("open sqlite for verification: %v", err)
+	}
+	defer verifyDB.Close()
+
+	if got := countRows(t, verifyDB); got != 1 {
+		t.Fatalf("analytics rows = %d, want 1", got)
+	}
+}
+
 func assertSQLiteObjectExists(t *testing.T, db *sql.DB, name string) {
 	t.Helper()
 	if countSQLiteObjects(t, db, name) != 1 {
@@ -146,6 +288,69 @@ SELECT COUNT(*)
 FROM sqlite_master
 WHERE name = ?`, name).Scan(&count); err != nil {
 		t.Fatalf("lookup %s: %v", name, err)
+	}
+	return count
+}
+
+func seedAnalyticsEvent(t *testing.T, db *sql.DB, ts int64) {
+	t.Helper()
+
+	if _, err := db.ExecContext(context.Background(), `
+INSERT INTO analytics_events (
+  ts,
+  event,
+  page,
+  created_at
+) VALUES (?, ?, ?, ?)`,
+		ts,
+		"page_view",
+		"home",
+		time.Unix(ts, 0).UTC().Format(time.RFC3339),
+	); err != nil {
+		t.Fatalf("seed analytics event: %v", err)
+	}
+}
+
+func assertAnalyticsEventTimestamps(t *testing.T, db *sql.DB, want ...int64) {
+	t.Helper()
+
+	rows, err := db.QueryContext(context.Background(), `
+SELECT ts
+FROM analytics_events
+ORDER BY ts ASC`)
+	if err != nil {
+		t.Fatalf("query analytics timestamps: %v", err)
+	}
+	defer rows.Close()
+
+	var got []int64
+	for rows.Next() {
+		var ts int64
+		if err := rows.Scan(&ts); err != nil {
+			t.Fatalf("scan analytics timestamp: %v", err)
+		}
+		got = append(got, ts)
+	}
+	if err := rows.Err(); err != nil {
+		t.Fatalf("iterate analytics timestamps: %v", err)
+	}
+
+	if len(got) != len(want) {
+		t.Fatalf("timestamps = %v, want %v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("timestamps = %v, want %v", got, want)
+		}
+	}
+}
+
+func countRows(t *testing.T, db *sql.DB) int {
+	t.Helper()
+
+	var count int
+	if err := db.QueryRowContext(context.Background(), `SELECT COUNT(*) FROM analytics_events`).Scan(&count); err != nil {
+		t.Fatalf("count analytics rows: %v", err)
 	}
 	return count
 }


### PR DESCRIPTION
Implements raw analytics event retention cleanup for the analytics SQLite store.

Closes #50.

Validation:
- go test ./internal/analytics
- go test ./cmd/server
- go test ./...
- git diff --check
