### PR TITLE
Update artifact actions for Node 24

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -163,7 +163,7 @@ jobs:
 
       - name: Upload report candidates
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: report-candidates
           path: .artifacts/report-candidates/docs/

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,7 +79,7 @@ jobs:
 
       - name: Upload report candidates
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: report-candidates
           path: .artifacts/report-candidates/docs/

--- a/.github/workflows/import-report-candidate.yml
+++ b/.github/workflows/import-report-candidate.yml
@@ -67,7 +67,7 @@ jobs:
           ref: ${{ steps.target.outputs.branch }}
 
       - name: Download report candidate artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: report-candidates
           run-id: ${{ inputs.source_run_id }}


### PR DESCRIPTION
## Summary
- update report artifact upload/download actions to Node 24-ready major versions
- keep CI/CD report candidate behavior unchanged

## Verification
- `ruby -e 'require "yaml"; ARGV.each { |f| YAML.load_file(f); puts "#{f} ok" }' .github/workflows/ci.yml .github/workflows/cd.yml .github/workflows/import-report-candidate.yml`
- `git diff --check`
