### PR TITLE
[codex] Add Linode artifact deployment path

### DIFF
--- a/.github/workflows/deploy-linode.yml
+++ b/.github/workflows/deploy-linode.yml
@@ -1,0 +1,222 @@
+name: Deploy Linode
+
+on:
+  workflow_dispatch:
+    inputs:
+      environment:
+        description: "GitHub deployment environment."
+        required: true
+        default: "staging"
+        type: choice
+        options:
+          - staging
+          - production
+      version:
+        description: "Existing release artifact version to deploy."
+        required: true
+        type: string
+      run_verify:
+        description: "Run deploy/verify.sh on the remote host after restart."
+        required: true
+        default: true
+        type: boolean
+
+permissions:
+  contents: read
+
+concurrency:
+  group: realtek-connect-linode-${{ inputs.environment }}
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    name: Deploy release to Linode
+    runs-on: ubuntu-latest
+    environment: ${{ inputs.environment }}
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v6
+
+      - name: Select version
+        id: version
+        shell: bash
+        env:
+          INPUT_VERSION: ${{ inputs.version }}
+        run: |
+          version="$INPUT_VERSION"
+          case "$version" in
+            *[!A-Za-z0-9._-]* | "" | .* | *..*)
+              echo "invalid version: use only letters, digits, dot, underscore, and dash" >&2
+              exit 1
+              ;;
+          esac
+          printf 'version=%s\n' "$version" >> "$GITHUB_OUTPUT"
+
+      - name: Download release bundle from Linode Object Storage
+        shell: bash
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.LINODE_OBJ_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.LINODE_OBJ_SECRET_ACCESS_KEY }}
+          AWS_DEFAULT_REGION: us-sea
+          AWS_EC2_METADATA_DISABLED: "true"
+          LINODE_OBJ_BUCKET: ${{ vars.LINODE_OBJ_BUCKET }}
+          LINODE_OBJ_ENDPOINT: ${{ vars.LINODE_OBJ_ENDPOINT }}
+          VERSION: ${{ steps.version.outputs.version }}
+        run: |
+          set -euo pipefail
+          if ! command -v aws >/dev/null 2>&1; then
+            python3 -m pip install --user awscli
+            export PATH="$HOME/.local/bin:$PATH"
+          fi
+          test -n "$AWS_ACCESS_KEY_ID"
+          test -n "$AWS_SECRET_ACCESS_KEY"
+          test -n "$LINODE_OBJ_BUCKET"
+          test -n "$LINODE_OBJ_ENDPOINT"
+          rm -rf dist
+          mkdir -p dist
+          prefix="s3://$LINODE_OBJ_BUCKET/releases/$VERSION"
+          aws s3 cp "$prefix/realtek-connect-$VERSION.tar.gz" "dist/realtek-connect-$VERSION.tar.gz" --endpoint-url "$LINODE_OBJ_ENDPOINT" --only-show-errors
+          aws s3 cp "$prefix/realtek-connect-$VERSION.tar.gz.sha256" "dist/realtek-connect-$VERSION.tar.gz.sha256" --endpoint-url "$LINODE_OBJ_ENDPOINT" --only-show-errors
+          aws s3 cp "$prefix/manifest.json" "dist/realtek-connect-$VERSION.object-manifest.json" --endpoint-url "$LINODE_OBJ_ENDPOINT" --only-show-errors
+          (cd dist && shasum -a 256 -c "realtek-connect-$VERSION.tar.gz.sha256")
+          tar -C dist -xzf "dist/realtek-connect-$VERSION.tar.gz"
+
+      - name: Verify release bundle
+        run: deploy/check-release.sh "dist/realtek-connect-${{ steps.version.outputs.version }}"
+
+      - name: Validate deployment inputs
+        shell: bash
+        env:
+          REALTEK_CONNECT_DEPLOY_PREFIX: ${{ vars.REALTEK_CONNECT_DEPLOY_PREFIX }}
+          REALTEK_CONNECT_DEPLOY_ETC_DIR: ${{ vars.REALTEK_CONNECT_DEPLOY_ETC_DIR }}
+          REALTEK_CONNECT_DEPLOY_SYSTEMD_DIR: ${{ vars.REALTEK_CONNECT_DEPLOY_SYSTEMD_DIR }}
+          REALTEK_CONNECT_DEPLOY_DATA_DIR: ${{ vars.REALTEK_CONNECT_DEPLOY_DATA_DIR }}
+          REALTEK_CONNECT_DEPLOY_REMOTE_DIR: ${{ vars.REALTEK_CONNECT_DEPLOY_REMOTE_DIR }}
+          REALTEK_CONNECT_PUBLIC_BASE_URL: ${{ vars.REALTEK_CONNECT_PUBLIC_BASE_URL }}
+        run: |
+          valid_path='^/[A-Za-z0-9._/-]+$'
+          [[ "${REALTEK_CONNECT_DEPLOY_PREFIX:-/opt/realtek-connect}" =~ $valid_path ]]
+          [[ "${REALTEK_CONNECT_DEPLOY_ETC_DIR:-/etc/realtek-connect}" =~ $valid_path ]]
+          [[ "${REALTEK_CONNECT_DEPLOY_SYSTEMD_DIR:-/etc/systemd/system}" =~ $valid_path ]]
+          [[ "${REALTEK_CONNECT_DEPLOY_DATA_DIR:-/var/lib/realtek-connect}" =~ $valid_path ]]
+          [[ "${REALTEK_CONNECT_DEPLOY_REMOTE_DIR:-/tmp/realtek-connect-deploy}" =~ $valid_path ]]
+          test -n "$REALTEK_CONNECT_PUBLIC_BASE_URL"
+
+      - name: Configure SSH
+        shell: bash
+        env:
+          REALTEK_CONNECT_DEPLOY_HOST: ${{ secrets.REALTEK_CONNECT_DEPLOY_HOST }}
+          REALTEK_CONNECT_DEPLOY_USER: ${{ secrets.REALTEK_CONNECT_DEPLOY_USER }}
+          REALTEK_CONNECT_DEPLOY_SSH_KEY: ${{ secrets.REALTEK_CONNECT_DEPLOY_SSH_KEY }}
+          REALTEK_CONNECT_DEPLOY_PORT: ${{ secrets.REALTEK_CONNECT_DEPLOY_PORT }}
+        run: |
+          test -n "$REALTEK_CONNECT_DEPLOY_HOST"
+          test -n "$REALTEK_CONNECT_DEPLOY_USER"
+          test -n "$REALTEK_CONNECT_DEPLOY_SSH_KEY"
+          mkdir -p ~/.ssh
+          chmod 700 ~/.ssh
+          printf '%s\n' "$REALTEK_CONNECT_DEPLOY_SSH_KEY" > ~/.ssh/realtek_connect_deploy
+          chmod 600 ~/.ssh/realtek_connect_deploy
+          port="${REALTEK_CONNECT_DEPLOY_PORT:-22}"
+          ssh-keyscan -p "$port" "$REALTEK_CONNECT_DEPLOY_HOST" >> ~/.ssh/known_hosts
+
+      - name: Upload bundle
+        shell: bash
+        env:
+          REALTEK_CONNECT_DEPLOY_HOST: ${{ secrets.REALTEK_CONNECT_DEPLOY_HOST }}
+          REALTEK_CONNECT_DEPLOY_USER: ${{ secrets.REALTEK_CONNECT_DEPLOY_USER }}
+          REALTEK_CONNECT_DEPLOY_PORT: ${{ secrets.REALTEK_CONNECT_DEPLOY_PORT }}
+          REALTEK_CONNECT_DEPLOY_REMOTE_DIR: ${{ vars.REALTEK_CONNECT_DEPLOY_REMOTE_DIR }}
+          VERSION: ${{ steps.version.outputs.version }}
+        run: |
+          port="${REALTEK_CONNECT_DEPLOY_PORT:-22}"
+          remote_dir="${REALTEK_CONNECT_DEPLOY_REMOTE_DIR:-/tmp/realtek-connect-deploy}"
+          ssh -i ~/.ssh/realtek_connect_deploy -p "$port" \
+            "$REALTEK_CONNECT_DEPLOY_USER@$REALTEK_CONNECT_DEPLOY_HOST" \
+            "mkdir -p -- \"$remote_dir\""
+          scp -i ~/.ssh/realtek_connect_deploy -P "$port" \
+            "dist/realtek-connect-$VERSION.tar.gz" \
+            "$REALTEK_CONNECT_DEPLOY_USER@$REALTEK_CONNECT_DEPLOY_HOST:$remote_dir/"
+
+      - name: Install and restart
+        shell: bash
+        env:
+          REALTEK_CONNECT_DEPLOY_HOST: ${{ secrets.REALTEK_CONNECT_DEPLOY_HOST }}
+          REALTEK_CONNECT_DEPLOY_USER: ${{ secrets.REALTEK_CONNECT_DEPLOY_USER }}
+          REALTEK_CONNECT_DEPLOY_PORT: ${{ secrets.REALTEK_CONNECT_DEPLOY_PORT }}
+          REALTEK_CONNECT_DEPLOY_REMOTE_DIR: ${{ vars.REALTEK_CONNECT_DEPLOY_REMOTE_DIR }}
+          REALTEK_CONNECT_DEPLOY_PREFIX: ${{ vars.REALTEK_CONNECT_DEPLOY_PREFIX }}
+          REALTEK_CONNECT_DEPLOY_ETC_DIR: ${{ vars.REALTEK_CONNECT_DEPLOY_ETC_DIR }}
+          REALTEK_CONNECT_DEPLOY_SYSTEMD_DIR: ${{ vars.REALTEK_CONNECT_DEPLOY_SYSTEMD_DIR }}
+          REALTEK_CONNECT_DEPLOY_DATA_DIR: ${{ vars.REALTEK_CONNECT_DEPLOY_DATA_DIR }}
+          REALTEK_CONNECT_PUBLIC_BASE_URL: ${{ vars.REALTEK_CONNECT_PUBLIC_BASE_URL }}
+          VERSION: ${{ steps.version.outputs.version }}
+          RUN_VERIFY: ${{ inputs.run_verify }}
+        run: |
+          port="${REALTEK_CONNECT_DEPLOY_PORT:-22}"
+          remote_dir="${REALTEK_CONNECT_DEPLOY_REMOTE_DIR:-/tmp/realtek-connect-deploy}"
+          prefix="${REALTEK_CONNECT_DEPLOY_PREFIX:-/opt/realtek-connect}"
+          etc_dir="${REALTEK_CONNECT_DEPLOY_ETC_DIR:-/etc/realtek-connect}"
+          systemd_dir="${REALTEK_CONNECT_DEPLOY_SYSTEMD_DIR:-/etc/systemd/system}"
+          data_dir="${REALTEK_CONNECT_DEPLOY_DATA_DIR:-/var/lib/realtek-connect}"
+          ssh -i ~/.ssh/realtek_connect_deploy -p "$port" \
+            "$REALTEK_CONNECT_DEPLOY_USER@$REALTEK_CONNECT_DEPLOY_HOST" \
+            "bash -s" -- "$remote_dir" "$VERSION" "$prefix" "$etc_dir" "$systemd_dir" "$data_dir" "$REALTEK_CONNECT_PUBLIC_BASE_URL" "$RUN_VERIFY" <<'REMOTE'
+          set -eu
+          remote_dir=$1
+          version=$2
+          prefix=$3
+          etc_dir=$4
+          systemd_dir=$5
+          data_dir=$6
+          public_base_url=$7
+          run_verify=$8
+
+          cd "$remote_dir"
+          previous_version=$(sudo sh -c "cat \"$prefix/current-version\" 2>/dev/null || true")
+          rm -rf "realtek-connect-$version"
+          tar -xzf "realtek-connect-$version.tar.gz"
+          sudo "./realtek-connect-$version/deploy/install.sh" "realtek-connect-$version" "$prefix" "$etc_dir" "$systemd_dir" "$data_dir"
+          if sudo grep -q '^PUBLIC_BASE_URL=' "$etc_dir/realtek-connect.env"; then
+            sudo sed -i "s|^PUBLIC_BASE_URL=.*|PUBLIC_BASE_URL=$public_base_url|" "$etc_dir/realtek-connect.env"
+          else
+            printf 'PUBLIC_BASE_URL=%s\n' "$public_base_url" | sudo tee -a "$etc_dir/realtek-connect.env" >/dev/null
+          fi
+          sudo systemctl daemon-reload
+          sudo systemctl enable realtek-connect.service
+          sudo systemctl restart realtek-connect.service
+          if [ "$run_verify" = "true" ]; then
+            sudo REALTEK_CONNECT_VERIFY_BASE_URL="$public_base_url" REALTEK_CONNECT_DEPLOY_PREFIX="$prefix" "$prefix/current/deploy/verify.sh"
+          fi
+          if [ -n "$previous_version" ]; then
+            printf '%s\n' "$previous_version" | sudo tee "$prefix/previous-version" >/dev/null
+          fi
+          printf '%s\n' "$version" | sudo tee "$prefix/current-version" >/dev/null
+          test "$(sudo cat "$prefix/current-version")" = "$version"
+          REMOTE
+
+      - name: Upload deployment summary
+        if: always()
+        shell: bash
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
+          RUN_VERIFY: ${{ inputs.run_verify }}
+        run: |
+          mkdir -p .artifacts/deploy
+          {
+            echo "# Realtek Connect+ Linode Deploy Summary"
+            echo
+            echo "- Version: $VERSION"
+            echo "- Environment: ${{ inputs.environment }}"
+            echo "- Commit: $GITHUB_SHA"
+            echo "- Public base URL: ${{ vars.REALTEK_CONNECT_PUBLIC_BASE_URL }}"
+            echo "- Run verify: $RUN_VERIFY"
+          } > .artifacts/deploy/linode-deploy-summary.md
+
+      - name: Upload deployment summary artifact
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: linode-deploy-summary-${{ steps.version.outputs.version }}
+          path: .artifacts/deploy/linode-deploy-summary.md
+          if-no-files-found: warn

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,132 @@
+name: Release Bundle
+
+on:
+  push:
+    tags:
+      - "v*"
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Release version. Defaults to tag name or short SHA."
+        required: false
+        type: string
+
+permissions:
+  contents: write
+
+jobs:
+  package:
+    name: Package release
+    runs-on: [self-hosted, rtk_cloud_frontend, go]
+    steps:
+      - name: Reset self-hosted workspace
+        shell: bash
+        run: |
+          find "$GITHUB_WORKSPACE" -mindepth 1 -maxdepth 1 -exec rm -rf {} +
+
+      - name: Check out repository
+        uses: actions/checkout@v6
+
+      - name: Select version
+        id: version
+        shell: bash
+        env:
+          INPUT_VERSION: ${{ inputs.version }}
+        run: |
+          if [ -n "$INPUT_VERSION" ]; then
+            version="$INPUT_VERSION"
+          elif [[ "$GITHUB_REF" == refs/tags/* ]]; then
+            version="$GITHUB_REF_NAME"
+          else
+            version="${GITHUB_SHA::12}"
+          fi
+          case "$version" in
+            *[!A-Za-z0-9._-]* | "" | .* | *..*)
+              echo "invalid version: use only letters, digits, dot, underscore, and dash" >&2
+              exit 1
+              ;;
+          esac
+          printf 'version=%s\n' "$version" >> "$GITHUB_OUTPUT"
+
+      - name: Check Go toolchain
+        run: go version
+
+      - name: Check Go formatting
+        shell: bash
+        run: |
+          files="$(git ls-files '*.go')"
+          unformatted="$(gofmt -l $files)"
+          if [ -n "$unformatted" ]; then
+            echo "Unformatted Go files:"
+            echo "$unformatted"
+            exit 1
+          fi
+
+      - name: Run tests
+        run: go test ./...
+
+      - name: Build release bundle
+        shell: bash
+        run: |
+          chmod +x deploy/*.sh
+          deploy/package.sh "${{ steps.version.outputs.version }}"
+
+      - name: Verify release bundle
+        run: deploy/check-release.sh "dist/realtek-connect-${{ steps.version.outputs.version }}"
+
+      - name: Upload release bundle to Linode Object Storage
+        shell: bash
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.LINODE_OBJ_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.LINODE_OBJ_SECRET_ACCESS_KEY }}
+          AWS_DEFAULT_REGION: us-sea
+          AWS_EC2_METADATA_DISABLED: "true"
+          LINODE_OBJ_BUCKET: ${{ vars.LINODE_OBJ_BUCKET }}
+          LINODE_OBJ_ENDPOINT: ${{ vars.LINODE_OBJ_ENDPOINT }}
+          VERSION: ${{ steps.version.outputs.version }}
+        run: |
+          set -euo pipefail
+          if ! command -v aws >/dev/null 2>&1; then
+            python3 -m pip install --user awscli
+            export PATH="$HOME/.local/bin:$PATH"
+          fi
+          test -n "$AWS_ACCESS_KEY_ID"
+          test -n "$AWS_SECRET_ACCESS_KEY"
+          test -n "$LINODE_OBJ_BUCKET"
+          test -n "$LINODE_OBJ_ENDPOINT"
+          prefix="s3://$LINODE_OBJ_BUCKET/releases/$VERSION"
+          aws s3 cp "dist/realtek-connect-$VERSION.tar.gz" "$prefix/realtek-connect-$VERSION.tar.gz" --endpoint-url "$LINODE_OBJ_ENDPOINT" --only-show-errors
+          aws s3 cp "dist/realtek-connect-$VERSION.tar.gz.sha256" "$prefix/realtek-connect-$VERSION.tar.gz.sha256" --endpoint-url "$LINODE_OBJ_ENDPOINT" --only-show-errors
+          aws s3 cp "dist/realtek-connect-$VERSION.object-manifest.json" "$prefix/manifest.json" --endpoint-url "$LINODE_OBJ_ENDPOINT" --only-show-errors
+
+      - name: Upload workflow artifact
+        uses: actions/upload-artifact@v7
+        with:
+          name: realtek-connect-${{ steps.version.outputs.version }}
+          path: |
+            dist/realtek-connect-${{ steps.version.outputs.version }}
+            dist/realtek-connect-${{ steps.version.outputs.version }}.tar.gz
+            dist/realtek-connect-${{ steps.version.outputs.version }}.tar.gz.sha256
+            dist/realtek-connect-${{ steps.version.outputs.version }}.object-manifest.json
+          if-no-files-found: error
+
+      - name: Publish GitHub release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          VERSION: ${{ steps.version.outputs.version }}
+        run: |
+          if gh release view "$VERSION" >/dev/null 2>&1; then
+            gh release upload "$VERSION" \
+              "dist/realtek-connect-$VERSION.tar.gz" \
+              "dist/realtek-connect-$VERSION.tar.gz.sha256" \
+              "dist/realtek-connect-$VERSION.object-manifest.json" \
+              --clobber
+          else
+            gh release create "$VERSION" \
+              "dist/realtek-connect-$VERSION.tar.gz" \
+              "dist/realtek-connect-$VERSION.tar.gz.sha256" \
+              "dist/realtek-connect-$VERSION.object-manifest.json" \
+              --generate-notes \
+              --target "$GITHUB_SHA" \
+              --title "$VERSION"
+          fi

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 bin/
+dist/
 /server
 .artifacts/
 data/*.db

--- a/README.md
+++ b/README.md
@@ -199,3 +199,13 @@ Deployment notes:
 - The native CD bundle includes a writable `data/` directory for test-host defaults. Production native deployments should still set `DATABASE_PATH` and `ANALYTICS_DATABASE_PATH` to a persistent service-owned directory.
 - The container serves HTTP on port `8080`. Production TLS termination should be handled by a reverse proxy, ingress, or deployment platform in front of the app.
 - Native builds remain supported for environments that prefer `go build` over containers.
+
+Artifact-based Linode deployment is also supported:
+
+- `deploy/package.sh <version>` creates `dist/realtek-connect-<version>.tar.gz`, a checksum, and an object-storage manifest.
+- `.github/workflows/release.yml` publishes release bundles to GitHub Releases and Linode Object Storage under `releases/<version>/`.
+- `.github/workflows/deploy-linode.yml` installs a selected version onto a standalone Linode VM and verifies public health.
+- Linode VM, GoDaddy DNS, nginx, TLS, rollback, and SQLite backup runbooks live in:
+  - `docs/deployment-linode.md`
+  - `docs/deployment-promotion-rollback.md`
+  - `docs/sqlite-backup-linode.md`

--- a/deploy/check-release.sh
+++ b/deploy/check-release.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+target="${1:-}"
+if [[ -z "$target" ]]; then
+  echo "usage: $0 <release-dir|release-tar.gz>" >&2
+  exit 2
+fi
+
+cleanup=""
+if [[ -f "$target" ]]; then
+  cleanup="$(mktemp -d)"
+  tar -C "$cleanup" -xzf "$target"
+  release_dir="$(find "$cleanup" -mindepth 1 -maxdepth 1 -type d | head -n 1)"
+else
+  release_dir="$target"
+fi
+trap 'if [[ -n "${cleanup:-}" ]]; then rm -rf "$cleanup"; fi' EXIT
+
+fail() {
+  echo "check-release failed: $*" >&2
+  exit 1
+}
+
+[[ -d "$release_dir" ]] || fail "release directory not found: $release_dir"
+[[ -x "$release_dir/bin/realtek-connect" ]] || fail "missing executable bin/realtek-connect"
+[[ -f "$release_dir/VERSION" ]] || fail "missing VERSION"
+[[ -f "$release_dir/release-manifest.json" ]] || fail "missing release-manifest.json"
+[[ -d "$release_dir/content" ]] || fail "missing content/"
+[[ -d "$release_dir/templates" ]] || fail "missing templates/"
+[[ -d "$release_dir/static" ]] || fail "missing static/"
+[[ -d "$release_dir/deploy" ]] || fail "missing deploy/"
+[[ -x "$release_dir/deploy/install.sh" ]] || fail "missing executable deploy/install.sh"
+[[ -x "$release_dir/deploy/verify.sh" ]] || fail "missing executable deploy/verify.sh"
+[[ -d "$release_dir/data" ]] || fail "missing data/"
+
+if find "$release_dir" -type f \( -name '*.db' -o -name '*.db-shm' -o -name '*.db-wal' \) | grep -q .; then
+  fail "release bundle must not include SQLite runtime DB files"
+fi
+
+python3 - "$release_dir/release-manifest.json" "$release_dir/VERSION" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+manifest = json.loads(Path(sys.argv[1]).read_text())
+version = Path(sys.argv[2]).read_text().strip()
+required = {"artifact", "binary_sha256", "created_at", "includes", "source_commit", "version"}
+missing = sorted(required - set(manifest))
+if missing:
+    raise SystemExit(f"manifest missing keys: {', '.join(missing)}")
+if manifest["version"] != version:
+    raise SystemExit("manifest version does not match VERSION")
+if not isinstance(manifest["includes"], list) or not manifest["includes"]:
+    raise SystemExit("manifest includes must be a non-empty list")
+PY
+
+echo "release bundle ok: $release_dir"

--- a/deploy/install.sh
+++ b/deploy/install.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+release_dir="${1:-}"
+prefix="${2:-/opt/realtek-connect}"
+etc_dir="${3:-/etc/realtek-connect}"
+systemd_dir="${4:-/etc/systemd/system}"
+data_dir="${5:-/var/lib/realtek-connect}"
+
+if [[ -z "$release_dir" ]]; then
+  echo "usage: $0 <release-dir> [prefix] [etc-dir] [systemd-dir] [data-dir]" >&2
+  exit 2
+fi
+
+version="$(cat "$release_dir/VERSION")"
+install_dir="$prefix/releases/$version"
+service_file="$systemd_dir/realtek-connect.service"
+env_file="$etc_dir/realtek-connect.env"
+
+install -d -m 0755 "$prefix/releases" "$etc_dir" "$systemd_dir"
+install -d -m 0750 "$data_dir" "$data_dir/backups"
+rm -rf "$install_dir"
+install -d -m 0755 "$install_dir"
+cp -R "$release_dir"/. "$install_dir/"
+chmod 0755 "$install_dir/bin/realtek-connect" "$install_dir/deploy/"*.sh
+
+if [[ ! -f "$env_file" ]]; then
+  cat > "$env_file" <<EOF
+PORT=8080
+DATABASE_PATH=$data_dir/connectplus.db
+ANALYTICS_DATABASE_PATH=$data_dir/analytics.db
+PUBLIC_BASE_URL=
+DISABLE_SEARCH_INDEXING=true
+ENABLE_ASSET_FINGERPRINTS=true
+ENABLE_CDN_CACHE_HEADERS=false
+ANALYTICS_ENABLED=true
+ADMIN_TOKEN=change-me-before-public-use
+EOF
+  chmod 0640 "$env_file"
+fi
+
+cat > "$service_file" <<EOF
+[Unit]
+Description=Realtek Connect+ website
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+EnvironmentFile=$env_file
+WorkingDirectory=$prefix/current
+ExecStart=$prefix/current/bin/realtek-connect
+Restart=on-failure
+RestartSec=5
+ReadWritePaths=$data_dir
+NoNewPrivileges=true
+
+[Install]
+WantedBy=multi-user.target
+EOF
+
+ln -sfn "$install_dir" "$prefix/current"
+echo "installed realtek-connect $version into $install_dir"

--- a/deploy/package.sh
+++ b/deploy/package.sh
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+version="${1:-${VERSION:-}}"
+if [[ -z "$version" ]]; then
+  echo "usage: $0 <version>" >&2
+  exit 2
+fi
+case "$version" in
+  *[!A-Za-z0-9._-]* | "" | .* | *..*)
+    echo "invalid version: use only letters, digits, dot, underscore, and dash" >&2
+    exit 2
+    ;;
+esac
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd -P)"
+dist_dir="$repo_root/dist"
+release_name="realtek-connect-$version"
+release_dir="$dist_dir/$release_name"
+bundle="$dist_dir/$release_name.tar.gz"
+checksum="$bundle.sha256"
+object_manifest="$dist_dir/$release_name.object-manifest.json"
+
+rm -rf "$release_dir" "$bundle" "$checksum" "$object_manifest"
+mkdir -p "$release_dir/bin" "$release_dir/data"
+
+GOOS="${GOOS:-linux}" GOARCH="${GOARCH:-amd64}" CGO_ENABLED="${CGO_ENABLED:-0}" \
+  go build -o "$release_dir/bin/realtek-connect" ./cmd/server
+
+cp -R "$repo_root/content" "$release_dir/"
+cp -R "$repo_root/templates" "$release_dir/"
+cp -R "$repo_root/static" "$release_dir/"
+cp -R "$repo_root/deploy" "$release_dir/"
+chmod 0755 "$release_dir/bin/realtek-connect" "$release_dir/deploy/"*.sh
+chmod 0775 "$release_dir/data"
+printf '%s\n' "$version" > "$release_dir/VERSION"
+
+source_commit="$(git -C "$repo_root" rev-parse HEAD 2>/dev/null || echo unknown)"
+created_at="$(date -u +"%Y-%m-%dT%H:%M:%SZ")"
+binary_sha="$(shasum -a 256 "$release_dir/bin/realtek-connect" | awk '{print $1}')"
+
+python3 - "$release_dir/release-manifest.json" "$version" "$source_commit" "$created_at" "$binary_sha" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+out, version, source_commit, created_at, binary_sha = sys.argv[1:]
+manifest = {
+    "artifact": f"realtek-connect-{version}",
+    "binary_sha256": binary_sha,
+    "created_at": created_at,
+    "includes": ["bin/realtek-connect", "content/", "templates/", "static/", "deploy/", "VERSION"],
+    "source_commit": source_commit,
+    "version": version,
+}
+Path(out).write_text(json.dumps(manifest, indent=2, sort_keys=True) + "\n")
+PY
+
+tar -C "$dist_dir" -czf "$bundle" "$release_name"
+bundle_sha="$(shasum -a 256 "$bundle" | awk '{print $1}')"
+printf '%s  %s\n' "$bundle_sha" "$(basename "$bundle")" > "$checksum"
+
+python3 - "$object_manifest" "$version" "$source_commit" "$created_at" "$bundle_sha" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+out, version, source_commit, created_at, bundle_sha = sys.argv[1:]
+bundle = f"realtek-connect-{version}.tar.gz"
+manifest = {
+    "artifact_path": f"releases/{version}/{bundle}",
+    "bundle": bundle,
+    "created_at": created_at,
+    "sha256": bundle_sha,
+    "source_commit": source_commit,
+    "version": version,
+}
+Path(out).write_text(json.dumps(manifest, indent=2, sort_keys=True) + "\n")
+PY
+
+"$repo_root/deploy/check-release.sh" "$release_dir"
+
+printf '%s\n' "$bundle"

--- a/deploy/verify.sh
+++ b/deploy/verify.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+base_url="${REALTEK_CONNECT_VERIFY_BASE_URL:-${PUBLIC_BASE_URL:-http://127.0.0.1:8080}}"
+prefix="${REALTEK_CONNECT_DEPLOY_PREFIX:-/opt/realtek-connect}"
+
+curl_common=(curl -fsS --max-time 20)
+health="$("${curl_common[@]}" "$base_url/healthz")"
+[[ "$health" == "ok" ]]
+
+home="$(mktemp)"
+trap 'rm -f "$home" "$headers"' EXIT
+"${curl_common[@]}" "$base_url/" > "$home"
+grep -q "Realtek Connect" "$home"
+grep -q "Contact Us" "$home"
+if grep -q "Contact Sales" "$home"; then
+  echo "stale Contact Sales copy found" >&2
+  exit 1
+fi
+
+headers="$(mktemp)"
+curl -fsSI --max-time 20 "$base_url/static/assets/realtek-logo.png" > "$headers"
+grep -qi "content-type: image/" "$headers"
+
+curl -fsSI --max-time 20 "$base_url/static/assets/realtek-brand-film.mp4" > "$headers"
+grep -qi "content-type: video/mp4" "$headers"
+awk 'BEGIN { ok = 0 } tolower($1) == "content-length:" && $2 + 0 > 1000000 { ok = 1 } END { exit ok ? 0 : 1 }' "$headers"
+
+if [[ -f "$prefix/current-version" ]]; then
+  test -s "$prefix/current-version"
+fi
+
+echo "realtek-connect verify ok: $base_url"

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -16,6 +16,7 @@ Implemented today:
 - Runtime entrypoint under `cmd/server` with request logging, graceful shutdown, and baseline read/write/idle timeouts.
 - Server-rendered pages using `html/template`.
 - Static CSS with a Realtek-style white, deep navy, and blue-green/teal visual system.
+- Artifact-first Linode deployment path with release bundles, Linode Object Storage publication, manual VM deploy workflow, rollback runbook, and SQLite backup policy.
 - Corporate hero/platform image stored in `static/assets/connectplus-hero-corporate-v2.jpg`.
 - Corporate feature and platform visuals stored under `static/assets/`, including the SDK sample ecosystem diagram at `static/assets/connectplus-sample-ecosystem-corporate-v2.jpg`.
 - Per-page title, description, canonical, Open Graph, and Twitter card metadata.
@@ -444,6 +445,14 @@ Container deployment notes:
 - The native CD bundle includes an empty writable `data/` directory so default `data/connectplus.db` and `data/analytics.db` paths can initialize on the website test host. Production native hosts should set `DATABASE_PATH` and `ANALYTICS_DATABASE_PATH` to persistent service-owned storage.
 - `/data` is declared as the persistent volume for SQLite-backed lead and analytics storage.
 - HTTPS is intentionally out of process and should be handled by the reverse proxy or deployment platform instead of the Go app directly.
+
+Linode artifact deployment notes:
+
+- `deploy/package.sh <version>` builds `dist/realtek-connect-<version>.tar.gz`, `realtek-connect-<version>.tar.gz.sha256`, and `realtek-connect-<version>.object-manifest.json`.
+- Release artifacts contain the server binary, `content/`, `templates/`, `static/`, `deploy/`, `VERSION`, and release manifest metadata. SQLite runtime DB files are excluded.
+- `.github/workflows/release.yml` publishes versioned artifacts to GitHub Releases and Linode Object Storage under `releases/<version>/`.
+- `.github/workflows/deploy-linode.yml` installs a selected version to `/opt/realtek-connect/releases/<version>`, updates `/opt/realtek-connect/current`, restarts `realtek-connect.service`, and runs public readiness checks.
+- Linode host bootstrap, GoDaddy DNS, nginx reverse proxy, Let’s Encrypt TLS, rollback, and SQLite backup are documented in `docs/deployment-linode.md`, `docs/deployment-promotion-rollback.md`, and `docs/sqlite-backup-linode.md`.
 
 Schema:
 

--- a/docs/deployment-linode.md
+++ b/docs/deployment-linode.md
@@ -1,0 +1,173 @@
+# Linode Artifact Deployment
+
+This runbook describes the standalone Linode deployment path for Realtek
+Connect+. It complements the existing `website-test.local` CD host; it does not
+replace that test deployment.
+
+## Deployment Model
+
+Realtek Connect+ uses an artifact-first deployment model:
+
+- CI builds `realtek-connect-<version>.tar.gz`.
+- The release workflow uploads the bundle, checksum, and manifest to GitHub
+  Releases and Linode Object Storage under `releases/<version>/`.
+- The Linode deploy workflow installs a selected version onto the VM.
+- Rollback deploys a previous published artifact version.
+
+Do not deploy production by copying a developer checkout to the VM.
+
+## GitHub Configuration
+
+Required secrets:
+
+- `LINODE_OBJ_ACCESS_KEY_ID`
+- `LINODE_OBJ_SECRET_ACCESS_KEY`
+- `REALTEK_CONNECT_DEPLOY_HOST`
+- `REALTEK_CONNECT_DEPLOY_USER`
+- `REALTEK_CONNECT_DEPLOY_SSH_KEY`
+- optional `REALTEK_CONNECT_DEPLOY_PORT`
+
+Required variables:
+
+- `LINODE_OBJ_BUCKET`
+- `LINODE_OBJ_ENDPOINT`
+- `REALTEK_CONNECT_PUBLIC_BASE_URL`
+
+Optional variables:
+
+- `REALTEK_CONNECT_DEPLOY_PREFIX`, default `/opt/realtek-connect`
+- `REALTEK_CONNECT_DEPLOY_ETC_DIR`, default `/etc/realtek-connect`
+- `REALTEK_CONNECT_DEPLOY_SYSTEMD_DIR`, default `/etc/systemd/system`
+- `REALTEK_CONNECT_DEPLOY_DATA_DIR`, default `/var/lib/realtek-connect`
+- `REALTEK_CONNECT_DEPLOY_REMOTE_DIR`, default `/tmp/realtek-connect-deploy`
+
+## Host Bootstrap
+
+Create a Linode VM with Ubuntu LTS or Debian stable, then install the runtime
+packages:
+
+```sh
+sudo apt update
+sudo apt install -y ca-certificates curl nginx sqlite3 openssl certbot python3-certbot-nginx
+```
+
+Create the runtime directories:
+
+```sh
+sudo mkdir -p /opt/realtek-connect/releases
+sudo mkdir -p /etc/realtek-connect
+sudo mkdir -p /var/lib/realtek-connect/backups
+sudo chown -R root:root /opt/realtek-connect /etc/realtek-connect
+sudo chmod 0755 /opt/realtek-connect /opt/realtek-connect/releases
+sudo chmod 0750 /var/lib/realtek-connect /var/lib/realtek-connect/backups
+```
+
+Create a deployment user with non-interactive sudo rights for install,
+systemd, and verification commands. A broad first version is acceptable for a
+private deployment host:
+
+```sh
+sudo useradd -m -s /bin/bash realtek-deploy || true
+echo 'realtek-deploy ALL=(root) NOPASSWD:ALL' | sudo tee /etc/sudoers.d/realtek-connect-deploy
+sudo chmod 0440 /etc/sudoers.d/realtek-connect-deploy
+sudo visudo -cf /etc/sudoers.d/realtek-connect-deploy
+```
+
+Add the public key that matches `REALTEK_CONNECT_DEPLOY_SSH_KEY` to
+`/home/realtek-deploy/.ssh/authorized_keys`.
+
+## Runtime Environment
+
+The first deployment creates `/etc/realtek-connect/realtek-connect.env` if it
+does not already exist. Review it before public launch:
+
+```dotenv
+PORT=8080
+DATABASE_PATH=/var/lib/realtek-connect/connectplus.db
+ANALYTICS_DATABASE_PATH=/var/lib/realtek-connect/analytics.db
+PUBLIC_BASE_URL=https://example.com
+DISABLE_SEARCH_INDEXING=true
+ENABLE_ASSET_FINGERPRINTS=true
+ENABLE_CDN_CACHE_HEADERS=false
+ANALYTICS_ENABLED=true
+ADMIN_TOKEN=change-me-before-public-use
+```
+
+Set `DISABLE_SEARCH_INDEXING=false` only when the site is ready to be indexed.
+Keep SQLite files in `/var/lib/realtek-connect`; they are runtime state and are
+never part of release artifacts.
+
+## GoDaddy DNS
+
+In GoDaddy DNS management:
+
+- Create an `A` record for the selected hostname pointing to the Linode public
+  IPv4 address.
+- Optionally create `www` as a CNAME to the apex or canonical hostname.
+- Keep TTL low during initial cutover, for example 600 seconds.
+
+Set `REALTEK_CONNECT_PUBLIC_BASE_URL` and the runtime `PUBLIC_BASE_URL` to the
+final HTTPS URL.
+
+## nginx And TLS
+
+The Go application stays HTTP-only on `127.0.0.1:8080`. nginx terminates public
+HTTP/HTTPS and proxies to the app:
+
+```nginx
+server {
+    listen 80;
+    server_name example.com www.example.com;
+
+    location / {
+        proxy_pass http://127.0.0.1:8080;
+        proxy_set_header Host $host;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+}
+```
+
+Enable the site, then issue TLS with Let’s Encrypt:
+
+```sh
+sudo nginx -t
+sudo systemctl reload nginx
+sudo certbot --nginx -d example.com -d www.example.com
+sudo systemctl status certbot.timer --no-pager
+```
+
+## First Release And Deploy
+
+Create a release artifact:
+
+```sh
+gh workflow run "Release Bundle" \
+  --repo hkt999rtk/rtk_cloud_frontend \
+  --ref main \
+  -f version=v0.1.0-linode-test
+```
+
+Deploy that version:
+
+```sh
+gh workflow run "Deploy Linode" \
+  --repo hkt999rtk/rtk_cloud_frontend \
+  --ref main \
+  -f environment=staging \
+  -f version=v0.1.0-linode-test \
+  -f run_verify=true
+```
+
+After deployment:
+
+```sh
+sudo systemctl status realtek-connect --no-pager
+cat /opt/realtek-connect/current-version
+curl -fsS https://example.com/healthz
+```
+
+## Related Runbooks
+
+- [deployment-promotion-rollback.md](deployment-promotion-rollback.md)
+- [sqlite-backup-linode.md](sqlite-backup-linode.md)

--- a/docs/deployment-promotion-rollback.md
+++ b/docs/deployment-promotion-rollback.md
@@ -1,0 +1,117 @@
+# Linode Promotion And Rollback Runbook
+
+Use this runbook to promote a published Realtek Connect+ artifact to a Linode
+environment and roll back to a previous artifact when needed.
+
+## Promotion Prerequisites
+
+Do not deploy until all of these are true:
+
+- CI on the candidate commit is green.
+- `Release Bundle` produced `realtek-connect-<version>.tar.gz`.
+- The bundle, checksum, and manifest exist in Linode Object Storage under
+  `releases/<version>/`.
+- `deploy/check-release.sh` passed for the same bundle.
+- The Linode VM has nginx, TLS, systemd, SQLite storage, and the deploy user
+  configured according to [deployment-linode.md](deployment-linode.md).
+- `REALTEK_CONNECT_PUBLIC_BASE_URL` points at the public HTTPS URL.
+
+## Deploy
+
+Run the manual workflow:
+
+```sh
+gh workflow run "Deploy Linode" \
+  --repo hkt999rtk/rtk_cloud_frontend \
+  --ref main \
+  -f environment=production \
+  -f version=<target-version> \
+  -f run_verify=true
+```
+
+During the run, confirm:
+
+- checksum validation passed
+- release bundle verification passed
+- SSH upload succeeded
+- `realtek-connect.service` restarted
+- `deploy/verify.sh` passed
+- deployment summary artifact was uploaded
+
+On the host, confirm:
+
+```sh
+sudo systemctl is-active realtek-connect
+cat /opt/realtek-connect/current-version
+cat /opt/realtek-connect/previous-version 2>/dev/null || true
+curl -fsS https://example.com/healthz
+```
+
+## Readiness Checks
+
+The verifier checks:
+
+- `GET /healthz` returns `ok`
+- homepage contains `Realtek Connect` and `Contact Us`
+- homepage does not contain stale `Contact Sales` copy
+- Realtek logo static asset is reachable
+- local MP4 brand film is served as `video/mp4` and is larger than 1 MB
+- `current-version` exists when the deploy workflow has written it
+
+For public launch, also manually check:
+
+- `/robots.txt` matches the intended indexing setting
+- `/sitemap.xml` returns the public hostname when indexing is enabled
+- `/privacy` is reachable
+- contact form writes to SQLite
+- admin access requires `ADMIN_TOKEN`
+
+## Rollback
+
+Rollback uses the same deployment workflow with the previous known-good version.
+Do not roll back by copying files from a developer machine or checking out old
+git state on the VM.
+
+Select the rollback version in this order:
+
+1. `/opt/realtek-connect/previous-version` if the failed deployment completed
+   far enough to write version files.
+2. The version recorded in the deployment sign-off notes.
+3. The most recent known-good GitHub Release / Linode Object Storage artifact.
+
+Run:
+
+```sh
+gh workflow run "Deploy Linode" \
+  --repo hkt999rtk/rtk_cloud_frontend \
+  --ref main \
+  -f environment=production \
+  -f version=<rollback-version> \
+  -f run_verify=true
+```
+
+After rollback:
+
+- confirm `current-version` equals the rollback version
+- confirm `/healthz` and homepage checks pass
+- check `journalctl -u realtek-connect -n 200 --no-pager`
+- record the failed version and rollback workflow URL
+
+SQLite databases are not rolled back by release artifact rollback. If data
+restore is needed, use [sqlite-backup-linode.md](sqlite-backup-linode.md).
+
+## Diagnostics
+
+Before or after rollback, collect:
+
+```sh
+sudo systemctl status realtek-connect --no-pager
+sudo journalctl -u realtek-connect -n 200 --no-pager
+sudo /opt/realtek-connect/current/deploy/verify.sh
+ls -la /opt/realtek-connect/releases
+cat /opt/realtek-connect/current-version
+cat /opt/realtek-connect/previous-version 2>/dev/null || true
+```
+
+Do not paste raw environment files, `ADMIN_TOKEN`, SSH keys, object storage
+secrets, or private DNS information into GitHub issues or PRs.

--- a/docs/sqlite-backup-linode.md
+++ b/docs/sqlite-backup-linode.md
@@ -1,0 +1,89 @@
+# Linode SQLite Backup Policy
+
+Realtek Connect+ stores runtime website data in SQLite on the deployment host.
+Release artifacts must never include these files.
+
+Default database paths:
+
+- `/var/lib/realtek-connect/connectplus.db`
+- `/var/lib/realtek-connect/analytics.db`
+
+Default backup directory:
+
+- `/var/lib/realtek-connect/backups`
+
+## Backup Command
+
+Use SQLite's online backup API instead of copying live DB files directly:
+
+```sh
+sudo install -d -m 0750 /var/lib/realtek-connect/backups
+ts="$(date -u +%Y%m%dT%H%M%SZ)"
+sudo sqlite3 /var/lib/realtek-connect/connectplus.db \
+  ".backup '/var/lib/realtek-connect/backups/connectplus-$ts.db'"
+sudo sqlite3 /var/lib/realtek-connect/analytics.db \
+  ".backup '/var/lib/realtek-connect/backups/analytics-$ts.db'"
+```
+
+Verify each backup:
+
+```sh
+sudo sqlite3 "/var/lib/realtek-connect/backups/connectplus-$ts.db" "PRAGMA integrity_check;"
+sudo sqlite3 "/var/lib/realtek-connect/backups/analytics-$ts.db" "PRAGMA integrity_check;"
+```
+
+The expected output is `ok`.
+
+## Retention
+
+Recommended first-version retention:
+
+- keep daily backups for 14 days
+- keep weekly backups for 8 weeks
+- keep monthly backups for 6 months if the environment is used for real leads
+
+Local retention cleanup can start with:
+
+```sh
+sudo find /var/lib/realtek-connect/backups -type f -name '*.db' -mtime +60 -delete
+```
+
+Adjust retention before public launch based on privacy and legal requirements.
+
+## Optional Object Storage Copy
+
+For production, copy verified backups to a private Linode Object Storage bucket
+prefix such as `sqlite-backups/<hostname>/`. Do not use the public release
+artifact prefix for database backups.
+
+```sh
+aws s3 cp "/var/lib/realtek-connect/backups/connectplus-$ts.db" \
+  "s3://$LINODE_OBJ_BUCKET/sqlite-backups/$(hostname)/connectplus-$ts.db" \
+  --endpoint-url "$LINODE_OBJ_ENDPOINT"
+```
+
+## Restore Procedure
+
+Restores should be deliberate because they replace runtime data.
+
+```sh
+sudo systemctl stop realtek-connect
+sudo cp /var/lib/realtek-connect/connectplus.db \
+  /var/lib/realtek-connect/connectplus.db.pre-restore
+sudo cp /var/lib/realtek-connect/backups/connectplus-YYYYMMDDTHHMMSSZ.db \
+  /var/lib/realtek-connect/connectplus.db
+sudo sqlite3 /var/lib/realtek-connect/connectplus.db "PRAGMA integrity_check;"
+sudo systemctl start realtek-connect
+curl -fsS https://example.com/healthz
+```
+
+Repeat the same pattern for `analytics.db` when analytics data must be
+restored.
+
+## Operational Notes
+
+- Backups are runtime data management, not release packaging.
+- Do not commit `.db`, `.db-wal`, `.db-shm`, or backup files to git.
+- Do not include database files in `realtek-connect-<version>.tar.gz`.
+- Redact lead emails and analytics data before attaching backup-derived output
+  to GitHub issues.


### PR DESCRIPTION
## Summary
- Add versioned release bundle packaging with manifest/checksum validation.
- Add release workflow publishing artifacts to GitHub Releases and Linode Object Storage.
- Add manual Linode deploy workflow that installs a selected artifact, restarts systemd, verifies public health, and records version files.
- Add Linode/GoDaddy/nginx/TLS bootstrap, promotion/rollback, and SQLite backup runbooks.

## Validation
- `bash -n deploy/*.sh`
- workflow YAML parse with Ruby/Psych
- `deploy/package.sh test-linode-artifact`
- `deploy/check-release.sh dist/realtek-connect-test-linode-artifact.tar.gz`
- `go test ./...`
- `go build ./cmd/server`
- `go run ./cmd/visual-smoke`

Closes #100
Closes #101
Closes #102
Closes #103
Closes #104
Closes #105
