### PR TITLE
Add CI Linode artifact publishing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,10 @@ on:
   push:
     branches:
       - main
+    tags:
+      - "v*"
   pull_request:
+  workflow_dispatch:
 
 concurrency:
   group: ci-${{ github.workflow }}-${{ github.event.pull_request.head.ref || github.ref_name }}
@@ -57,6 +60,12 @@ jobs:
         id: build
         run: go build ./cmd/server
 
+      - name: Select CI artifact version
+        id: artifact_version
+        shell: bash
+        run: |
+          printf 'version=ci-%s\n' "${GITHUB_SHA::12}" >> "$GITHUB_OUTPUT"
+
       - name: Build deployable bundle
         id: package
         shell: bash
@@ -65,16 +74,33 @@ jobs:
           SEARCH_EMBEDDING_MODEL: text-embedding-3-small
         run: |
           chmod +x deploy/*.sh
-          deploy/package.sh "ci-${GITHUB_SHA::12}"
-          deploy/check-release.sh "dist/realtek-connect-ci-${GITHUB_SHA::12}"
+          deploy/package.sh "${{ steps.artifact_version.outputs.version }}"
+          deploy/check-release.sh "dist/realtek-connect-${{ steps.artifact_version.outputs.version }}"
 
       - name: Upload deployable bundle
         uses: actions/upload-artifact@v7
         with:
-          name: realtek-connect-ci-${{ github.sha }}
+          name: realtek-connect-${{ steps.artifact_version.outputs.version }}
           path: |
-            dist/realtek-connect-ci-*
+            dist/realtek-connect-${{ steps.artifact_version.outputs.version }}
+            dist/realtek-connect-${{ steps.artifact_version.outputs.version }}.tar.gz
+            dist/realtek-connect-${{ steps.artifact_version.outputs.version }}.tar.gz.sha256
+            dist/realtek-connect-${{ steps.artifact_version.outputs.version }}.object-manifest.json
           if-no-files-found: error
+
+      - name: Upload deployable bundle to Linode Object Storage
+        if: github.event_name == 'workflow_dispatch' || startsWith(github.ref, 'refs/tags/') || github.ref == 'refs/heads/main'
+        shell: bash
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.LINODE_OBJ_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.LINODE_OBJ_SECRET_ACCESS_KEY }}
+          LINODE_TOKEN: ${{ secrets.LINODE_TOKEN }}
+          AWS_DEFAULT_REGION: us-sea
+          AWS_EC2_METADATA_DISABLED: "true"
+          LINODE_OBJ_BUCKET: ${{ vars.LINODE_OBJ_BUCKET }}
+          LINODE_OBJ_ENDPOINT: ${{ vars.LINODE_OBJ_ENDPOINT }}
+        run: |
+          deploy/upload-linode-artifact.sh "${{ steps.artifact_version.outputs.version }}"
 
       - name: Run visual smoke
         id: visual_smoke

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -82,25 +82,14 @@ jobs:
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.LINODE_OBJ_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.LINODE_OBJ_SECRET_ACCESS_KEY }}
+          LINODE_TOKEN: ${{ secrets.LINODE_TOKEN }}
           AWS_DEFAULT_REGION: us-sea
           AWS_EC2_METADATA_DISABLED: "true"
           LINODE_OBJ_BUCKET: ${{ vars.LINODE_OBJ_BUCKET }}
           LINODE_OBJ_ENDPOINT: ${{ vars.LINODE_OBJ_ENDPOINT }}
           VERSION: ${{ steps.version.outputs.version }}
         run: |
-          set -euo pipefail
-          if ! command -v aws >/dev/null 2>&1; then
-            python3 -m pip install --user awscli
-            export PATH="$HOME/.local/bin:$PATH"
-          fi
-          test -n "$AWS_ACCESS_KEY_ID"
-          test -n "$AWS_SECRET_ACCESS_KEY"
-          test -n "$LINODE_OBJ_BUCKET"
-          test -n "$LINODE_OBJ_ENDPOINT"
-          prefix="s3://$LINODE_OBJ_BUCKET/releases/$VERSION"
-          aws s3 cp "dist/realtek-connect-$VERSION.tar.gz" "$prefix/realtek-connect-$VERSION.tar.gz" --endpoint-url "$LINODE_OBJ_ENDPOINT" --only-show-errors
-          aws s3 cp "dist/realtek-connect-$VERSION.tar.gz.sha256" "$prefix/realtek-connect-$VERSION.tar.gz.sha256" --endpoint-url "$LINODE_OBJ_ENDPOINT" --only-show-errors
-          aws s3 cp "dist/realtek-connect-$VERSION.object-manifest.json" "$prefix/manifest.json" --endpoint-url "$LINODE_OBJ_ENDPOINT" --only-show-errors
+          deploy/upload-linode-artifact.sh "$VERSION"
 
       - name: Upload workflow artifact
         uses: actions/upload-artifact@v7

--- a/README.md
+++ b/README.md
@@ -217,7 +217,9 @@ Deployment notes:
 
 Artifact-based Linode deployment is also supported:
 
+- CI builds deployable `realtek-connect-ci-<shortsha>` artifacts for every PR, `main` push, tag, and manual run. On `main`, tags, and manual runs, CI also uploads the bundle, checksum, and manifest to Linode Object Storage under `releases/ci-<shortsha>/`.
 - `deploy/package.sh <version>` creates `dist/realtek-connect-<version>.tar.gz`, a checksum, and an object-storage manifest. When `OPENAI_API_KEY` is present, the bundle includes `data/search.db` as a precomputed documentation search index.
+- `deploy/upload-linode-artifact.sh <version>` uploads the release bundle, checksum, and manifest to Linode Object Storage using the S3-compatible HTTP API directly; it does not require the AWS CLI. It requires either `LINODE_OBJ_ACCESS_KEY_ID` and `LINODE_OBJ_SECRET_ACCESS_KEY`, or `LINODE_TOKEN` so it can create a temporary bucket-scoped Object Storage key. `LINODE_OBJ_BUCKET` and `LINODE_OBJ_ENDPOINT` may be provided explicitly; when only one bucket exists, the script can infer both from the Linode API.
 - `.github/workflows/release.yml` publishes release bundles to GitHub Releases and Linode Object Storage under `releases/<version>/`.
 - `.github/workflows/deploy-linode.yml` installs a selected version onto a standalone Linode VM and verifies public health.
 - Linode VM, GoDaddy DNS, nginx, TLS, rollback, and SQLite backup runbooks live in:

--- a/deploy/upload-linode-artifact.sh
+++ b/deploy/upload-linode-artifact.sh
@@ -1,0 +1,184 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+version="${1:-${VERSION:-}}"
+if [[ -z "$version" ]]; then
+  echo "usage: $0 <version>" >&2
+  exit 2
+fi
+case "$version" in
+  *[!A-Za-z0-9._-]* | "" | .* | *..*)
+    echo "invalid version: use only letters, digits, dot, underscore, and dash" >&2
+    exit 2
+    ;;
+esac
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd -P)"
+dist_dir="$repo_root/dist"
+bundle="$dist_dir/realtek-connect-$version.tar.gz"
+checksum="$bundle.sha256"
+manifest="$dist_dir/realtek-connect-$version.object-manifest.json"
+
+test -f "$bundle"
+test -f "$checksum"
+test -f "$manifest"
+
+linode_api="${LINODE_API_URL:-https://api.linode.com/v4}"
+temp_key_id=""
+bucket_region="${LINODE_OBJ_REGION:-${AWS_DEFAULT_REGION:-us-sea}}"
+
+delete_temp_key() {
+  if [[ -n "$temp_key_id" && -n "${LINODE_TOKEN:-}" ]]; then
+    curl -fsS -X DELETE \
+      -H "Authorization: Bearer $LINODE_TOKEN" \
+      "$linode_api/object-storage/keys/$temp_key_id" >/dev/null || true
+  fi
+}
+trap delete_temp_key EXIT
+
+if [[ -z "${AWS_ACCESS_KEY_ID:-}" || -z "${AWS_SECRET_ACCESS_KEY:-}" || -z "${LINODE_OBJ_BUCKET:-}" || -z "${LINODE_OBJ_ENDPOINT:-}" ]]; then
+  test -n "${LINODE_TOKEN:-}"
+  command -v curl >/dev/null 2>&1
+  command -v jq >/dev/null 2>&1
+
+  buckets_json="$(curl -fsS -H "Authorization: Bearer $LINODE_TOKEN" "$linode_api/object-storage/buckets")"
+  if [[ -z "${LINODE_OBJ_BUCKET:-}" ]]; then
+    bucket_count="$(jq '.data | length' <<<"$buckets_json")"
+    if [[ "$bucket_count" != "1" ]]; then
+      echo "LINODE_OBJ_BUCKET is required when the account has $bucket_count Object Storage buckets" >&2
+      jq -r '.data[].label' <<<"$buckets_json" >&2
+      exit 2
+    fi
+    LINODE_OBJ_BUCKET="$(jq -r '.data[0].label' <<<"$buckets_json")"
+  fi
+
+  bucket_json="$(jq -e --arg bucket "$LINODE_OBJ_BUCKET" '.data[] | select(.label == $bucket)' <<<"$buckets_json")"
+  bucket_region="$(jq -r '.region // .cluster // empty' <<<"$bucket_json")"
+  bucket_hostname="$(jq -r '.hostname // .s3_endpoint // empty' <<<"$bucket_json")"
+  test -n "$bucket_region"
+  if [[ -z "${LINODE_OBJ_ENDPOINT:-}" ]]; then
+    test -n "$bucket_hostname"
+    LINODE_OBJ_ENDPOINT="https://${bucket_hostname#${LINODE_OBJ_BUCKET}.}"
+  fi
+
+  key_label="realtek-connect-$version-$(date -u +%Y%m%d%H%M%S)"
+  key_payload="$(jq -n \
+    --arg label "$key_label" \
+    --arg bucket "$LINODE_OBJ_BUCKET" \
+    --arg region "$bucket_region" \
+    '{label: $label, bucket_access: [{bucket_name: $bucket, region: $region, permissions: "read_write"}]}')"
+  key_json="$(curl -fsS -X POST \
+    -H "Authorization: Bearer $LINODE_TOKEN" \
+    -H "Content-Type: application/json" \
+    --data "$key_payload" \
+    "$linode_api/object-storage/keys")"
+  temp_key_id="$(jq -r '.id // empty' <<<"$key_json")"
+  AWS_ACCESS_KEY_ID="$(jq -r '.access_key // empty' <<<"$key_json")"
+  AWS_SECRET_ACCESS_KEY="$(jq -r '.secret_key // empty' <<<"$key_json")"
+  test -n "$AWS_ACCESS_KEY_ID"
+  test -n "$AWS_SECRET_ACCESS_KEY"
+  export AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY LINODE_OBJ_BUCKET LINODE_OBJ_ENDPOINT
+fi
+
+test -n "${AWS_ACCESS_KEY_ID:-}"
+test -n "${AWS_SECRET_ACCESS_KEY:-}"
+test -n "${LINODE_OBJ_BUCKET:-}"
+test -n "${LINODE_OBJ_ENDPOINT:-}"
+test -n "$bucket_region"
+command -v curl >/dev/null 2>&1
+
+(
+  cd "$dist_dir"
+  shasum -a 256 -c "realtek-connect-$version.tar.gz.sha256"
+)
+
+prefix="s3://$LINODE_OBJ_BUCKET/releases/$version"
+
+s3_put() {
+  local file="$1"
+  local key="$2"
+  local endpoint_no_scheme="${LINODE_OBJ_ENDPOINT#https://}"
+  endpoint_no_scheme="${endpoint_no_scheme#http://}"
+  endpoint_no_scheme="${endpoint_no_scheme%%/}"
+  endpoint_no_scheme="${endpoint_no_scheme#${LINODE_OBJ_BUCKET}.}"
+  local scheme="https"
+  if [[ "$LINODE_OBJ_ENDPOINT" == http://* ]]; then
+    scheme="http"
+  fi
+  local host="$LINODE_OBJ_BUCKET.$endpoint_no_scheme"
+  local url="$scheme://$host/$key"
+  local encoded_key
+  encoded_key="$(python3 - "$key" <<'PY'
+import sys
+from urllib.parse import quote
+print("/".join(quote(part, safe="") for part in sys.argv[1].split("/")))
+PY
+)"
+  local signed_headers
+  signed_headers="$(python3 - "$file" "$host" "/$encoded_key" "$bucket_region" <<'PY'
+import datetime
+import hashlib
+import hmac
+import os
+import sys
+
+path, host, canonical_uri, region = sys.argv[1:]
+access_key = os.environ["AWS_ACCESS_KEY_ID"]
+secret_key = os.environ["AWS_SECRET_ACCESS_KEY"]
+service = "s3"
+payload_hash = hashlib.sha256(open(path, "rb").read()).hexdigest()
+now = datetime.datetime.now(datetime.timezone.utc)
+amz_date = now.strftime("%Y%m%dT%H%M%SZ")
+date_stamp = now.strftime("%Y%m%d")
+canonical_headers = (
+    f"host:{host}\n"
+    f"x-amz-content-sha256:{payload_hash}\n"
+    f"x-amz-date:{amz_date}\n"
+)
+signed_headers = "host;x-amz-content-sha256;x-amz-date"
+canonical_request = "\n".join([
+    "PUT",
+    canonical_uri,
+    "",
+    canonical_headers,
+    signed_headers,
+    payload_hash,
+])
+credential_scope = f"{date_stamp}/{region}/{service}/aws4_request"
+string_to_sign = "\n".join([
+    "AWS4-HMAC-SHA256",
+    amz_date,
+    credential_scope,
+    hashlib.sha256(canonical_request.encode()).hexdigest(),
+])
+def sign(key, msg):
+    return hmac.new(key, msg.encode(), hashlib.sha256).digest()
+signing_key = sign(sign(sign(sign(("AWS4" + secret_key).encode(), date_stamp), region), service), "aws4_request")
+signature = hmac.new(signing_key, string_to_sign.encode(), hashlib.sha256).hexdigest()
+authorization = (
+    f"AWS4-HMAC-SHA256 Credential={access_key}/{credential_scope}, "
+    f"SignedHeaders={signed_headers}, Signature={signature}"
+)
+print(f"x-amz-date:{amz_date}")
+print(f"x-amz-content-sha256:{payload_hash}")
+print(f"authorization:{authorization}")
+PY
+)"
+  local amz_date payload_hash authorization
+  amz_date="$(awk -F: '$1 == "x-amz-date" {print substr($0, index($0, ":") + 1)}' <<<"$signed_headers")"
+  payload_hash="$(awk -F: '$1 == "x-amz-content-sha256" {print substr($0, index($0, ":") + 1)}' <<<"$signed_headers")"
+  authorization="$(awk -F: '$1 == "authorization" {print substr($0, index($0, ":") + 1)}' <<<"$signed_headers")"
+  curl -fsS -X PUT \
+    -H "Host: $host" \
+    -H "x-amz-date: $amz_date" \
+    -H "x-amz-content-sha256: $payload_hash" \
+    -H "Authorization: $authorization" \
+    --upload-file "$file" \
+    "$url" >/dev/null
+}
+
+s3_put "$bundle" "releases/$version/realtek-connect-$version.tar.gz"
+s3_put "$checksum" "releases/$version/realtek-connect-$version.tar.gz.sha256"
+s3_put "$manifest" "releases/$version/manifest.json"
+
+echo "uploaded realtek-connect $version to $prefix"

--- a/docs/deployment-linode.md
+++ b/docs/deployment-linode.md
@@ -8,9 +8,13 @@ replace that test deployment.
 
 Realtek Connect+ uses an artifact-first deployment model:
 
-- CI builds `realtek-connect-<version>.tar.gz`.
-- The release workflow uploads the bundle, checksum, and manifest to GitHub
-  Releases and Linode Object Storage under `releases/<version>/`.
+- CI builds `realtek-connect-ci-<shortsha>.tar.gz` for every PR and push.
+- CI uploads every deployable bundle as a GitHub Actions artifact named
+  `realtek-connect-ci-<shortsha>`.
+- On `main`, tags, and manual runs, CI also uploads the bundle, checksum, and
+  manifest to Linode Object Storage under `releases/ci-<shortsha>/`.
+- The release workflow uploads explicit release bundles to GitHub Releases and
+  Linode Object Storage under `releases/<version>/`.
 - The Linode deploy workflow installs a selected version onto the VM.
 - Rollback deploys a previous published artifact version.
 
@@ -20,8 +24,10 @@ Do not deploy production by copying a developer checkout to the VM.
 
 Required secrets:
 
-- `LINODE_OBJ_ACCESS_KEY_ID`
-- `LINODE_OBJ_SECRET_ACCESS_KEY`
+- `LINODE_TOKEN`, used by CI to create a temporary bucket-scoped Object Storage
+  key for artifact upload.
+- Optional `LINODE_OBJ_ACCESS_KEY_ID` and `LINODE_OBJ_SECRET_ACCESS_KEY` if a
+  long-lived bucket-scoped key is preferred over temporary keys.
 - `REALTEK_CONNECT_DEPLOY_HOST`
 - `REALTEK_CONNECT_DEPLOY_USER`
 - `REALTEK_CONNECT_DEPLOY_SSH_KEY`
@@ -29,8 +35,10 @@ Required secrets:
 
 Required variables:
 
-- `LINODE_OBJ_BUCKET`
-- `LINODE_OBJ_ENDPOINT`
+- Optional `LINODE_OBJ_BUCKET`; required only when the Linode account has more
+  than one Object Storage bucket.
+- Optional `LINODE_OBJ_ENDPOINT`; inferred from the selected bucket hostname
+  when omitted.
 - `REALTEK_CONNECT_PUBLIC_BASE_URL`
 
 Optional variables:
@@ -40,6 +48,39 @@ Optional variables:
 - `REALTEK_CONNECT_DEPLOY_SYSTEMD_DIR`, default `/etc/systemd/system`
 - `REALTEK_CONNECT_DEPLOY_DATA_DIR`, default `/var/lib/realtek-connect`
 - `REALTEK_CONNECT_DEPLOY_REMOTE_DIR`, default `/tmp/realtek-connect-deploy`
+
+## CI Artifact Contract
+
+Every CI run builds and verifies a deployment-ready bundle:
+
+```text
+realtek-connect-ci-<shortsha>
+realtek-connect-ci-<shortsha>.tar.gz
+realtek-connect-ci-<shortsha>.tar.gz.sha256
+realtek-connect-ci-<shortsha>.object-manifest.json
+```
+
+For `main`, tags, and manual CI runs, the same files are published to Linode
+Object Storage:
+
+```text
+releases/ci-<shortsha>/realtek-connect-ci-<shortsha>.tar.gz
+releases/ci-<shortsha>/realtek-connect-ci-<shortsha>.tar.gz.sha256
+releases/ci-<shortsha>/manifest.json
+```
+
+Pull request CI never uploads to Object Storage and does not require Linode
+secrets. The bundle includes the binary, `content/`, `templates/`, `static/`,
+`deploy/`, `VERSION`, and release manifests. Runtime SQLite database files must
+not be included.
+
+The upload script supports two authentication modes. If
+`LINODE_OBJ_ACCESS_KEY_ID` and `LINODE_OBJ_SECRET_ACCESS_KEY` are present, it
+uses them directly with the Linode S3-compatible API. Otherwise it uses
+`LINODE_TOKEN` to create a temporary limited-access Object Storage key for the
+selected bucket, uploads through the S3-compatible API, and deletes the temporary
+key before exiting. It signs S3-compatible HTTP requests itself and does not
+require the AWS CLI on the runner.
 
 ## Host Bootstrap
 


### PR DESCRIPTION
## Summary
- Build and verify deployable `realtek-connect-ci-<shortsha>` bundles in CI.
- Upload CI bundles as GitHub Actions artifacts for every PR/push, and to Linode Object Storage for main/tag/manual runs.
- Add a shared Linode Object Storage uploader that can use `LINODE_TOKEN` to create a temporary bucket-scoped key and upload through the S3-compatible HTTP API without AWS CLI.

## Verification
- `bash -n deploy/*.sh`
- `git diff --check`
- `go test ./...`
- `go build ./cmd/server`
- `go run ./cmd/visual-smoke`
- `deploy/package.sh ci-local-test`
- `deploy/check-release.sh dist/realtek-connect-ci-local-test`
- `deploy/check-release.sh dist/realtek-connect-ci-local-test.tar.gz`
- Uploaded test artifact via `LINODE_TOKEN` to `s3://rtk-video-cloud-artifacts/releases/ci-local-test/` and confirmed `manifest.json`, tarball, and checksum via Linode API.