### PR TITLE
[codex] Remove GitHub artifact uploads

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -161,14 +161,6 @@ jobs:
           scripts/generate_report_candidate.sh cd .artifacts/report-candidates/docs/READINESS_TEST_REPORT.md
           scripts/validate_report_candidate.sh .artifacts/report-candidates/docs/READINESS_TEST_REPORT.md docs/READINESS_TEST_REPORT.md
 
-      - name: Upload report candidates
-        if: always()
-        uses: actions/upload-artifact@v7
-        with:
-          name: report-candidates
-          path: .artifacts/report-candidates/docs/
-          if-no-files-found: error
-
       - name: Check readiness report drift
         shell: bash
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,17 +77,6 @@ jobs:
           deploy/package.sh "${{ steps.artifact_version.outputs.version }}"
           deploy/check-release.sh "dist/realtek-connect-${{ steps.artifact_version.outputs.version }}"
 
-      - name: Upload deployable bundle
-        uses: actions/upload-artifact@v7
-        with:
-          name: realtek-connect-${{ steps.artifact_version.outputs.version }}
-          path: |
-            dist/realtek-connect-${{ steps.artifact_version.outputs.version }}
-            dist/realtek-connect-${{ steps.artifact_version.outputs.version }}.tar.gz
-            dist/realtek-connect-${{ steps.artifact_version.outputs.version }}.tar.gz.sha256
-            dist/realtek-connect-${{ steps.artifact_version.outputs.version }}.object-manifest.json
-          if-no-files-found: error
-
       - name: Upload deployable bundle to Linode Object Storage
         if: github.event_name == 'workflow_dispatch' || startsWith(github.ref, 'refs/tags/') || github.ref == 'refs/heads/main'
         shell: bash
@@ -127,14 +116,6 @@ jobs:
           chmod +x scripts/generate_report_candidate.sh scripts/validate_report_candidate.sh
           scripts/generate_report_candidate.sh ci .artifacts/report-candidates/docs/TEST_REPORT.md
           scripts/validate_report_candidate.sh .artifacts/report-candidates/docs/TEST_REPORT.md docs/TEST_REPORT.md
-
-      - name: Upload report candidates
-        if: always()
-        uses: actions/upload-artifact@v7
-        with:
-          name: report-candidates
-          path: .artifacts/report-candidates/docs/
-          if-no-files-found: error
 
       - name: Check CI report drift
         shell: bash

--- a/.github/workflows/deploy-linode.yml
+++ b/.github/workflows/deploy-linode.yml
@@ -212,11 +212,3 @@ jobs:
             echo "- Public base URL: ${{ vars.REALTEK_CONNECT_PUBLIC_BASE_URL }}"
             echo "- Run verify: $RUN_VERIFY"
           } > .artifacts/deploy/linode-deploy-summary.md
-
-      - name: Upload deployment summary artifact
-        if: always()
-        uses: actions/upload-artifact@v7
-        with:
-          name: linode-deploy-summary-${{ steps.version.outputs.version }}
-          path: .artifacts/deploy/linode-deploy-summary.md
-          if-no-files-found: warn

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -91,17 +91,6 @@ jobs:
         run: |
           deploy/upload-linode-artifact.sh "$VERSION"
 
-      - name: Upload workflow artifact
-        uses: actions/upload-artifact@v7
-        with:
-          name: realtek-connect-${{ steps.version.outputs.version }}
-          path: |
-            dist/realtek-connect-${{ steps.version.outputs.version }}
-            dist/realtek-connect-${{ steps.version.outputs.version }}.tar.gz
-            dist/realtek-connect-${{ steps.version.outputs.version }}.tar.gz.sha256
-            dist/realtek-connect-${{ steps.version.outputs.version }}.object-manifest.json
-          if-no-files-found: error
-
       - name: Publish GitHub release
         env:
           GH_TOKEN: ${{ github.token }}


### PR DESCRIPTION
## Summary

- remove every `actions/upload-artifact` step from GitHub Actions workflows
- keep release bundle publication on Linode Object Storage as the authoritative artifact path
- avoid GitHub artifact quota affecting CI/release outcomes

## Validation

- `ruby -e 'require "yaml"; Dir[".github/workflows/*.{yml,yaml}"].each { |f| YAML.load_file(f); puts f }'`
- `git diff --check`
- workspace-wide `rg "actions/upload-artifact|upload-artifact"` returned no matches
