### PR TITLE
[codex] Document frontend service logging migration

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,9 @@ The homepage includes a locally hosted Realtek corporate brand film at `static/a
 Privacy readiness is intentionally lightweight for this prototype: `/privacy` describes contact form data, first-party SQLite analytics when `ANALYTICS_ENABLED=true`, OpenAI-backed documentation query behavior when search is enabled, the analytics event types collected, referrer-origin-only handling, ephemeral session ids, 90-day raw analytics event retention, the 24-month lead retention intent, data request handling, admin protection, no third-party analytics or advertising pixels or fingerprinting, and local video behavior. Replace the placeholder `privacy@example.com` contact before public launch and complete legal review.
 
 The full roadmap and developer issue backlog live in [`docs/SPEC.md`](docs/SPEC.md).
+The service logging migration to `rtk_cloud_logger` zap and central journald
+forwarding is documented in
+[`docs/SERVICE_LOGGING_MIGRATION.md`](docs/SERVICE_LOGGING_MIGRATION.md).
 
 Content classification terms for future project discussions:
 

--- a/docs/SERVICE_LOGGING_MIGRATION.md
+++ b/docs/SERVICE_LOGGING_MIGRATION.md
@@ -1,0 +1,40 @@
+# Service Logging Migration
+
+Status: implementation handoff.
+
+Owner: `rtk_cloud_frontend`.
+
+## Goal
+
+Make the Realtek Connect+ frontend runtime logs compatible with the RTK Cloud
+central service logger while keeping website analytics, lead storage, and
+service logs as separate concerns.
+
+## Required Changes
+
+- Replace stdlib Go logging in `cmd/server` and `cmd/search-index` with
+  `rtk_cloud_logger` zap logging.
+- Emit server request logs as single-line JSON on stdout/stderr.
+- Preserve `request_id` and `trace_id` for documentation/search requests when
+  present.
+- Log search-index and content-load failures with structured fields.
+- Define forwarder labels for any non-Go web/runtime logs collected from nginx
+  or deployment-managed services.
+- Do not log lead form raw payloads, cookies, OpenAI/API keys, SMTP secrets, or
+  SQLite connection details with credentials.
+
+## Entrypoints To Cover
+
+- `cmd/server`
+- `cmd/search-index`
+- `deploy/install.sh`
+- `deploy/*.service` templates or generated units
+- nginx access/error logs in Linode deployments
+
+## Acceptance Criteria
+
+- `realtek-connect.service` emits JSON zap logs from Go processes.
+- HTTP request logs include status, latency, sanitized path, remote address,
+  and request id.
+- Search-index runs can be traced by `service`, `component`, and build version.
+- `go test ./...` and frontend build/test checks continue to pass.

--- a/docs/deployment-linode.md
+++ b/docs/deployment-linode.md
@@ -17,6 +17,9 @@ Realtek Connect+ uses an artifact-first deployment model:
   Linode Object Storage under `releases/realtek_connect-<version>/`.
 - The Linode deploy workflow installs a selected version onto the VM.
 - Rollback deploys a previous published artifact version.
+- Runtime Go service logs should emit `rtk_cloud_logger` zap JSON to
+  stdout/stderr for journald collection and central forwarding; see
+  `docs/SERVICE_LOGGING_MIGRATION.md`.
 
 Do not deploy production by copying a developer checkout to the VM.
 


### PR DESCRIPTION
## Summary\n- add frontend handoff doc for Go runtime/search-index migration to rtk_cloud_logger zap\n- cover request logging, search/content failures, nginx labels, and redaction\n- update README and Linode deployment docs\n\n## Validation\n- rg "SERVICE_LOGGING|rtk_cloud_logger|journald" README.md docs