### PR TITLE
Document website OpenAPI contract

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,9 @@ The full roadmap and developer issue backlog live in [`docs/SPEC.md`](docs/SPEC.
 The service logging migration to `rtk_cloud_logger` zap and central journald
 forwarding is documented in
 [`docs/SERVICE_LOGGING_MIGRATION.md`](docs/SERVICE_LOGGING_MIGRATION.md).
+The implemented website HTTP API is documented in
+[`docs/API_REFERENCE.md`](docs/API_REFERENCE.md), with a machine-readable
+OpenAPI contract in [`docs/openapi.yaml`](docs/openapi.yaml).
 
 Content classification terms for future project discussions:
 
@@ -123,7 +126,8 @@ CDN readiness:
 - `GET /admin/leads.csv`, requires `ADMIN_TOKEN`
 - `GET /static/...`
 
-New public routes should be documented here and in `docs/SPEC.md`.
+New public routes should be documented here, in `docs/SPEC.md`, and in
+`docs/openapi.yaml` when they expose an API or form contract.
 
 ## Multilingual Public Site
 

--- a/docs/API_REFERENCE.md
+++ b/docs/API_REFERENCE.md
@@ -1,0 +1,194 @@
+# Website API Reference
+
+This document summarizes the HTTP API implemented by `rtk_cloud_frontend`.
+The machine-readable OpenAPI contract lives in
+[`docs/openapi.yaml`](openapi.yaml).
+
+The website API is separate from future Realtek Connect+ product control-plane
+APIs. It only covers the marketing/documentation site runtime: analytics,
+documentation search, contact lead capture, health, and protected admin
+operations.
+
+## Authentication
+
+Public endpoints do not require authentication:
+
+- `POST /api/event`
+- `POST /api/search`
+- `GET /contact`, `POST /contact`
+- `GET /zh-tw/contact`, `POST /zh-tw/contact`
+- `GET /zh-cn/contact`, `POST /zh-cn/contact`
+- `GET /healthz`
+
+Admin endpoints require `ADMIN_TOKEN` when configured. Prefer the
+`X-Admin-Token` header:
+
+```bash
+curl -H "X-Admin-Token: $ADMIN_TOKEN" http://localhost:8080/admin/leads
+```
+
+The `token` query parameter remains available for manual browser access:
+
+```bash
+curl "http://localhost:8080/admin/leads.csv?token=$ADMIN_TOKEN"
+```
+
+When `ADMIN_TOKEN` is unset, admin endpoints return `404`.
+
+## Analytics Event API
+
+`POST /api/event`
+
+Stores a privacy-minimal analytics event when analytics storage is enabled.
+The endpoint accepts only `application/json` and a maximum 4 KB request body.
+Unknown JSON fields are ignored.
+
+```json
+{
+  "event": "click_cta",
+  "page": "home",
+  "cta": "contact_us",
+  "session_id": "2f3f4b7c-ephemeral"
+}
+```
+
+Allowed event types are `page_view`, `click_cta`, `scroll`, and `engaged`.
+The backend validates event-specific fields:
+
+- `click_cta` requires an allowlisted `cta`.
+- `scroll` requires `percent` set to `25`, `50`, `75`, or `100`.
+- `engaged` requires `duration` set to `10`, `30`, or `60`.
+
+Successful storage returns:
+
+```json
+{
+  "status": "ok"
+}
+```
+
+If analytics storage is disabled, the endpoint returns `204 No Content` and
+does not store anything.
+
+## Documentation Search API
+
+`POST /api/search`
+
+Queries the local documentation search index and returns a source-grounded
+answer when relevant website content is found.
+
+```json
+{
+  "query": "How do I enable documentation search?",
+  "locale": "en"
+}
+```
+
+`query` is required and limited to 500 characters. `locale` may be `en`,
+`zh-TW`, or `zh-CN`; omitted or unknown values default to `en`.
+
+Successful responses use this shape:
+
+```json
+{
+  "answer_found": true,
+  "answer": "Build the index with cmd/search-index, then start the server with SEARCH_ENABLED=true.",
+  "sources": [
+    {
+      "title": "README",
+      "url": "",
+      "snippet": "Build the local website-only search index with OPENAI_API_KEY...",
+      "locale": "en",
+      "source_type": "file",
+      "score": 0.82
+    }
+  ]
+}
+```
+
+When no retrieved source clears the relevance threshold, the response is still
+`200 OK` with `answer_found=false` and an empty `sources` array.
+
+Error responses include the same base fields plus `error`:
+
+```json
+{
+  "answer_found": false,
+  "answer": "Search is not enabled.",
+  "sources": [],
+  "error": "search_disabled"
+}
+```
+
+Documented error values are `search_disabled`, `rate_limited`,
+`invalid_json`, `invalid_query`, and `search_unavailable`.
+
+## Contact Lead Form
+
+`POST /contact`
+
+Localized variants:
+
+- `POST /zh-tw/contact`
+- `POST /zh-cn/contact`
+
+The contact form uses `application/x-www-form-urlencoded` fields:
+
+- `name`, required, max 120 characters.
+- `company`, optional, max 160 characters.
+- `email`, required valid email.
+- `interest`, required. Allowed values: `evaluation-access`,
+  `commercial-deployment`, `partnership`, `technical-question`, `other`.
+- `message`, optional, max 2000 characters.
+- `website`, spam-trap field; leave empty.
+
+Successful and validation responses render HTML. Rate limiting returns
+`429 Too Many Requests`.
+
+## Health
+
+`GET /healthz`
+
+Returns `200 OK` and a plain-text body:
+
+```text
+ok
+```
+
+The response is marked `Cache-Control: no-store`.
+
+## Admin Operations
+
+`GET /admin/leads`
+
+Renders the protected lead review page. Query filters:
+
+- `email`: partial email match.
+- `company`: partial company match.
+- `interest`: exact contact interest slug.
+- `page`: one-based page number.
+- `token`: query fallback for `ADMIN_TOKEN`.
+
+`GET /admin/leads.csv`
+
+Exports filtered leads as CSV with these columns:
+
+```text
+id,name,company,email,interest,message,created_at
+```
+
+`POST /admin/reload-content`
+
+Reloads docs and manual content from disk. On success, the response is:
+
+```text
+content reloaded
+```
+
+## Privacy And Logging Notes
+
+The website API must not log or store raw lead payloads, cookies, OpenAI/API
+keys, SMTP secrets, credentialed connection details, or full referrer URLs.
+Search query text may be sent to OpenAI for embeddings and source-grounded
+answers when `SEARCH_ENABLED=true`, but raw query text is not stored in the
+analytics event payload.

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -247,6 +247,8 @@ The website includes a first-version public documentation query tool scoped only
 
 - Public routes include `/search`, `/zh-tw/search`, and `/zh-cn/search`.
 - The query API is `POST /api/search` with JSON body `{ "query": "string", "locale": "en|zh-TW|zh-CN" }`.
+- The implemented website HTTP API contract is maintained in `docs/openapi.yaml`
+  and summarized for humans in `docs/API_REFERENCE.md`.
 - The search index is CLI-only and is not rebuilt during server startup. Run `OPENAI_API_KEY=... go run ./cmd/search-index` before enabling runtime search.
 - Release packaging can build a precomputed `data/search.db` into the deployable artifact when `OPENAI_API_KEY` is available. This keeps fixed website-document embeddings out of git while allowing deployment bundles to be search-ready.
 - The indexer scans website content from `content/`, `docs/`, `README.md`, feature/docs/manual catalog data, and localized public content, then stores documents, chunks, embeddings, and source metadata in SQLite.
@@ -359,6 +361,10 @@ Routes:
 - `GET /admin/leads`: protected lead review page, enabled only when `ADMIN_TOKEN` is set.
 - `GET /admin/leads.csv`: protected CSV export, enabled only when `ADMIN_TOKEN` is set.
 - `GET /static/...`: CSS and asset files.
+
+The OpenAPI contract in `docs/openapi.yaml` covers API/form/admin endpoints
+implemented by this website runtime. It intentionally does not describe the
+future IoT product control-plane APIs.
 
 Localized public route variants:
 

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -1,0 +1,756 @@
+openapi: 3.1.0
+info:
+  title: Realtek Connect+ Website API
+  version: 0.1.0
+  summary: HTTP API contract for the Realtek Connect+ marketing and documentation website.
+  description: >
+    This OpenAPI document covers the runtime endpoints implemented in
+    rtk_cloud_frontend. It documents the website-owned analytics, documentation
+    search, contact lead, health, and protected admin endpoints. It does not
+    describe the future IoT product control-plane APIs.
+servers:
+  - url: http://localhost:8080
+    description: Local development server.
+  - url: https://example.com
+    description: Deployed website origin. Replace with PUBLIC_BASE_URL.
+tags:
+  - name: Analytics
+    description: Privacy-minimal first-party website analytics.
+  - name: Search
+    description: OpenAI-backed documentation search scoped to website content.
+  - name: Contact
+    description: Contact and evaluation lead submission.
+  - name: Health
+    description: Runtime health endpoint.
+  - name: Admin
+    description: Token-protected internal website operations.
+paths:
+  /api/event:
+    post:
+      tags:
+        - Analytics
+      operationId: postAnalyticsEvent
+      summary: Record a first-party analytics event.
+      description: >
+        Stores an allowlisted website analytics event when analytics storage is
+        enabled. The endpoint ignores unknown JSON fields and does not accept
+        form data, raw URLs, user identifiers, cookies, or form field values.
+        When analytics is disabled, the endpoint returns 204 without storing.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/AnalyticsEventRequest"
+            examples:
+              pageView:
+                summary: Page view event.
+                value:
+                  event: page_view
+                  page: home
+                  session_id: 2f3f4b7c-ephemeral
+              clickCTA:
+                summary: CTA click event.
+                value:
+                  event: click_cta
+                  page: home
+                  cta: contact_us
+                  session_id: 2f3f4b7c-ephemeral
+              scroll:
+                summary: Scroll milestone event.
+                value:
+                  event: scroll
+                  page: docs
+                  percent: 50
+                  session_id: 2f3f4b7c-ephemeral
+              engaged:
+                summary: Engagement duration event.
+                value:
+                  event: engaged
+                  page: features
+                  duration: 10
+                  session_id: 2f3f4b7c-ephemeral
+      responses:
+        "202":
+          description: Event accepted and stored.
+          headers:
+            Cache-Control:
+              $ref: "#/components/headers/NoStore"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/StatusOK"
+              examples:
+                accepted:
+                  value:
+                    status: ok
+        "204":
+          description: Analytics storage is disabled; no event is stored.
+          headers:
+            Cache-Control:
+              $ref: "#/components/headers/NoStore"
+        "400":
+          description: Invalid JSON, unsupported event type, page, CTA, percent, duration, variant, or session id.
+          content:
+            text/plain:
+              schema:
+                type: string
+        "413":
+          description: Request body exceeds the 4 KB analytics payload limit.
+          content:
+            text/plain:
+              schema:
+                type: string
+        "415":
+          description: Content-Type is not application/json.
+          content:
+            text/plain:
+              schema:
+                type: string
+        "405":
+          $ref: "#/components/responses/MethodNotAllowed"
+  /api/search:
+    post:
+      tags:
+        - Search
+      operationId: postDocumentationSearch
+      summary: Query the website documentation search index.
+      description: >
+        Accepts a documentation question, embeds it, retrieves matching website
+        content from the local SQLite search index, and optionally asks the
+        configured answer model to generate a source-grounded answer. Raw query
+        text is not stored in the analytics event payload.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/SearchRequest"
+            examples:
+              english:
+                value:
+                  query: How do I enable documentation search?
+                  locale: en
+              traditionalChinese:
+                value:
+                  query: 如何啟用文件搜尋？
+                  locale: zh-TW
+      responses:
+        "200":
+          description: Search completed. The response may still indicate no matching answer.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/SearchResponse"
+              examples:
+                answered:
+                  value:
+                    answer_found: true
+                    answer: Build the index with cmd/search-index, then start the server with SEARCH_ENABLED=true.
+                    sources:
+                      - title: README
+                        url: ""
+                        snippet: Build the local website-only search index with OPENAI_API_KEY...
+                        locale: en
+                        source_type: file
+                        score: 0.82
+                noHit:
+                  value:
+                    answer_found: false
+                    answer: No matching documentation was found.
+                    sources: []
+        "400":
+          description: Invalid JSON or missing/too-long query.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/SearchErrorResponse"
+              examples:
+                invalidQuery:
+                  value:
+                    answer_found: false
+                    answer: Enter a search question up to 500 characters.
+                    sources: []
+                    error: invalid_query
+        "429":
+          description: Too many search requests from the same client address.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/SearchErrorResponse"
+              examples:
+                rateLimited:
+                  value:
+                    answer_found: false
+                    answer: Too many search requests. Please try again later.
+                    sources: []
+                    error: rate_limited
+        "502":
+          description: Search backend, embedding, answer model, or local index query failed.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/SearchErrorResponse"
+              examples:
+                unavailable:
+                  value:
+                    answer_found: false
+                    answer: Search is temporarily unavailable.
+                    sources: []
+                    error: search_unavailable
+        "503":
+          description: Search is disabled or no search service is configured.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/SearchErrorResponse"
+              examples:
+                disabled:
+                  value:
+                    answer_found: false
+                    answer: Search is not enabled.
+                    sources: []
+                    error: search_disabled
+        "405":
+          $ref: "#/components/responses/MethodNotAllowed"
+  /contact:
+    get:
+      tags:
+        - Contact
+      operationId: getContactForm
+      summary: Render the English contact form.
+      responses:
+        "200":
+          description: HTML contact form.
+          content:
+            text/html:
+              schema:
+                type: string
+    post:
+      tags:
+        - Contact
+      operationId: postContactForm
+      summary: Submit a contact or evaluation lead.
+      description: >
+        Validates and stores a lead in SQLite. Localized variants are available
+        at /zh-tw/contact and /zh-cn/contact and use the same form fields.
+        The hidden website field is a spam trap and must stay empty.
+      requestBody:
+        required: true
+        content:
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: "#/components/schemas/ContactFormRequest"
+            examples:
+              technicalQuestion:
+                value:
+                  name: Alex Chen
+                  company: Example Devices
+                  email: alex@example.com
+                  interest: technical-question
+                  message: We are evaluating OTA and private deployment options.
+                  website: ""
+      responses:
+        "200":
+          description: HTML confirmation page. Validation failures also render HTML with an error summary and a 400 status.
+          content:
+            text/html:
+              schema:
+                type: string
+        "400":
+          description: Invalid form encoding, spam-trap hit, missing required fields, invalid email, invalid interest, or field length violation.
+          content:
+            text/html:
+              schema:
+                type: string
+        "429":
+          description: Too many contact submissions from the same client address.
+          content:
+            text/html:
+              schema:
+                type: string
+        "500":
+          description: Lead storage failed.
+          content:
+            text/plain:
+              schema:
+                type: string
+        "405":
+          $ref: "#/components/responses/MethodNotAllowed"
+  /zh-tw/contact:
+    get:
+      tags:
+        - Contact
+      operationId: getTraditionalChineseContactForm
+      summary: Render the Traditional Chinese contact form.
+      responses:
+        "200":
+          description: HTML contact form.
+          content:
+            text/html:
+              schema:
+                type: string
+    post:
+      tags:
+        - Contact
+      operationId: postTraditionalChineseContactForm
+      summary: Submit a Traditional Chinese contact or evaluation lead.
+      requestBody:
+        required: true
+        content:
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: "#/components/schemas/ContactFormRequest"
+      responses:
+        "200":
+          description: HTML confirmation page.
+          content:
+            text/html:
+              schema:
+                type: string
+        "400":
+          description: Invalid form data.
+          content:
+            text/html:
+              schema:
+                type: string
+        "429":
+          description: Too many contact submissions from the same client address.
+          content:
+            text/html:
+              schema:
+                type: string
+        "500":
+          description: Lead storage failed.
+          content:
+            text/plain:
+              schema:
+                type: string
+  /zh-cn/contact:
+    get:
+      tags:
+        - Contact
+      operationId: getSimplifiedChineseContactForm
+      summary: Render the Simplified Chinese contact form.
+      responses:
+        "200":
+          description: HTML contact form.
+          content:
+            text/html:
+              schema:
+                type: string
+    post:
+      tags:
+        - Contact
+      operationId: postSimplifiedChineseContactForm
+      summary: Submit a Simplified Chinese contact or evaluation lead.
+      requestBody:
+        required: true
+        content:
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: "#/components/schemas/ContactFormRequest"
+      responses:
+        "200":
+          description: HTML confirmation page.
+          content:
+            text/html:
+              schema:
+                type: string
+        "400":
+          description: Invalid form data.
+          content:
+            text/html:
+              schema:
+                type: string
+        "429":
+          description: Too many contact submissions from the same client address.
+          content:
+            text/html:
+              schema:
+                type: string
+        "500":
+          description: Lead storage failed.
+          content:
+            text/plain:
+              schema:
+                type: string
+  /healthz:
+    get:
+      tags:
+        - Health
+      operationId: getHealthz
+      summary: Check website process health.
+      responses:
+        "200":
+          description: The website process is serving HTTP traffic.
+          headers:
+            Cache-Control:
+              $ref: "#/components/headers/NoStore"
+          content:
+            text/plain:
+              schema:
+                type: string
+              examples:
+                ok:
+                  value: "ok\n"
+        "405":
+          $ref: "#/components/responses/MethodNotAllowed"
+  /admin/leads:
+    get:
+      tags:
+        - Admin
+      operationId: getAdminLeads
+      summary: Render protected lead review page.
+      security:
+        - adminTokenHeader: []
+        - adminTokenQuery: []
+      parameters:
+        - $ref: "#/components/parameters/AdminTokenQuery"
+        - $ref: "#/components/parameters/LeadEmailFilter"
+        - $ref: "#/components/parameters/LeadCompanyFilter"
+        - $ref: "#/components/parameters/LeadInterestFilter"
+        - $ref: "#/components/parameters/PageQuery"
+      responses:
+        "200":
+          description: HTML lead review page with filtered, paginated leads.
+          content:
+            text/html:
+              schema:
+                type: string
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "404":
+          description: Admin lead review is disabled because ADMIN_TOKEN is unset.
+          content:
+            text/plain:
+              schema:
+                type: string
+        "500":
+          description: Lead storage query failed.
+          content:
+            text/plain:
+              schema:
+                type: string
+  /admin/leads.csv:
+    get:
+      tags:
+        - Admin
+      operationId: getAdminLeadsCSV
+      summary: Export protected lead records as CSV.
+      security:
+        - adminTokenHeader: []
+        - adminTokenQuery: []
+      parameters:
+        - $ref: "#/components/parameters/AdminTokenQuery"
+        - $ref: "#/components/parameters/LeadEmailFilter"
+        - $ref: "#/components/parameters/LeadCompanyFilter"
+        - $ref: "#/components/parameters/LeadInterestFilter"
+      responses:
+        "200":
+          description: CSV export with id, name, company, email, interest, message, and created_at columns.
+          content:
+            text/csv:
+              schema:
+                type: string
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "404":
+          description: Admin CSV export is disabled because ADMIN_TOKEN is unset.
+          content:
+            text/plain:
+              schema:
+                type: string
+        "500":
+          description: Lead storage query failed.
+          content:
+            text/plain:
+              schema:
+                type: string
+  /admin/reload-content:
+    post:
+      tags:
+        - Admin
+      operationId: postAdminReloadContent
+      summary: Reload docs and manual content from disk.
+      security:
+        - adminTokenHeader: []
+        - adminTokenQuery: []
+      parameters:
+        - $ref: "#/components/parameters/AdminTokenQuery"
+      responses:
+        "200":
+          description: Content cache reloaded.
+          content:
+            text/plain:
+              schema:
+                type: string
+              examples:
+                reloaded:
+                  value: "content reloaded\n"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "404":
+          description: Admin reload is disabled because ADMIN_TOKEN is unset.
+          content:
+            text/plain:
+              schema:
+                type: string
+        "500":
+          description: Docs or manual content could not be reloaded.
+          content:
+            text/plain:
+              schema:
+                type: string
+components:
+  securitySchemes:
+    adminTokenHeader:
+      type: apiKey
+      in: header
+      name: X-Admin-Token
+      description: ADMIN_TOKEN value configured on the website process.
+    adminTokenQuery:
+      type: apiKey
+      in: query
+      name: token
+      description: ADMIN_TOKEN query fallback. Prefer X-Admin-Token for manual or scripted requests.
+  headers:
+    NoStore:
+      description: Response must not be cached.
+      schema:
+        type: string
+        example: no-store
+  parameters:
+    AdminTokenQuery:
+      name: token
+      in: query
+      required: false
+      description: ADMIN_TOKEN query fallback.
+      schema:
+        type: string
+    LeadEmailFilter:
+      name: email
+      in: query
+      required: false
+      description: Case-insensitive partial email filter.
+      schema:
+        type: string
+    LeadCompanyFilter:
+      name: company
+      in: query
+      required: false
+      description: Case-insensitive partial company filter.
+      schema:
+        type: string
+    LeadInterestFilter:
+      name: interest
+      in: query
+      required: false
+      description: Exact contact interest slug filter.
+      schema:
+        $ref: "#/components/schemas/ContactInterest"
+    PageQuery:
+      name: page
+      in: query
+      required: false
+      description: One-based lead review page number.
+      schema:
+        type: integer
+        minimum: 1
+        default: 1
+  responses:
+    MethodNotAllowed:
+      description: HTTP method is not allowed for this route.
+      headers:
+        Allow:
+          description: Comma-separated allowed methods.
+          schema:
+            type: string
+      content:
+        text/plain:
+          schema:
+            type: string
+    Unauthorized:
+      description: Missing or invalid admin token.
+      content:
+        text/plain:
+          schema:
+            type: string
+  schemas:
+    AnalyticsEventRequest:
+      type: object
+      additionalProperties: true
+      required:
+        - event
+        - page
+        - session_id
+      properties:
+        event:
+          type: string
+          enum:
+            - page_view
+            - click_cta
+            - scroll
+            - engaged
+        page:
+          type: string
+          description: Allowlisted canonical page key rendered by the website, not a raw URL.
+          examples:
+            - home
+            - docs
+            - features
+            - contact
+        cta:
+          type: string
+          description: Required for click_cta events and rejected for other event types.
+          examples:
+            - contact_us
+        percent:
+          type: integer
+          enum:
+            - 25
+            - 50
+            - 75
+            - 100
+          description: Required for scroll events and rejected for other event types.
+        duration:
+          type: integer
+          enum:
+            - 10
+            - 30
+            - 60
+          description: Required for engaged events and rejected for other event types.
+        variant:
+          type: string
+          description: Optional allowlisted experiment key.
+        session_id:
+          type: string
+          minLength: 1
+          maxLength: 64
+          pattern: "^[A-Za-z0-9._:-]+$"
+          description: Ephemeral in-memory browser session id.
+    StatusOK:
+      type: object
+      required:
+        - status
+      properties:
+        status:
+          type: string
+          enum:
+            - ok
+    SearchRequest:
+      type: object
+      additionalProperties: false
+      required:
+        - query
+      properties:
+        query:
+          type: string
+          minLength: 1
+          maxLength: 500
+          description: Documentation search question.
+        locale:
+          type: string
+          enum:
+            - en
+            - zh-TW
+            - zh-CN
+          default: en
+    SearchResponse:
+      type: object
+      required:
+        - answer_found
+        - answer
+        - sources
+      properties:
+        answer_found:
+          type: boolean
+        answer:
+          type: string
+        sources:
+          type: array
+          maxItems: 5
+          items:
+            $ref: "#/components/schemas/SearchSource"
+    SearchErrorResponse:
+      allOf:
+        - $ref: "#/components/schemas/SearchResponse"
+        - type: object
+          required:
+            - error
+          properties:
+            error:
+              type: string
+              enum:
+                - search_disabled
+                - rate_limited
+                - invalid_json
+                - invalid_query
+                - search_unavailable
+    SearchSource:
+      type: object
+      required:
+        - title
+        - url
+        - snippet
+        - locale
+        - source_type
+        - score
+      properties:
+        title:
+          type: string
+        url:
+          type: string
+          description: Public path for website content sources; may be empty for repository files.
+        snippet:
+          type: string
+        locale:
+          type: string
+          enum:
+            - en
+            - zh-TW
+            - zh-CN
+        source_type:
+          type: string
+          examples:
+            - docs
+            - manual
+            - feature
+            - file
+        score:
+          type: number
+          format: double
+    ContactFormRequest:
+      type: object
+      required:
+        - name
+        - email
+        - interest
+      properties:
+        name:
+          type: string
+          minLength: 1
+          maxLength: 120
+        company:
+          type: string
+          maxLength: 160
+        email:
+          type: string
+          format: email
+        interest:
+          $ref: "#/components/schemas/ContactInterest"
+        message:
+          type: string
+          maxLength: 2000
+        website:
+          type: string
+          description: Spam trap field. Leave empty.
+          maxLength: 0
+    ContactInterest:
+      type: string
+      enum:
+        - evaluation-access
+        - commercial-deployment
+        - partnership
+        - technical-question
+        - other

--- a/docs/openapi_test.go
+++ b/docs/openapi_test.go
@@ -1,0 +1,54 @@
+package docs_test
+
+import (
+	"os"
+	"testing"
+
+	"gopkg.in/yaml.v3"
+)
+
+func TestOpenAPIDocumentCoversRuntimeEndpoints(t *testing.T) {
+	contents, err := os.ReadFile("openapi.yaml")
+	if err != nil {
+		t.Fatalf("read openapi.yaml: %v", err)
+	}
+
+	var document struct {
+		OpenAPI string                    `yaml:"openapi"`
+		Info    map[string]any            `yaml:"info"`
+		Paths   map[string]map[string]any `yaml:"paths"`
+	}
+	if err := yaml.Unmarshal(contents, &document); err != nil {
+		t.Fatalf("parse openapi.yaml: %v", err)
+	}
+
+	if document.OpenAPI != "3.1.0" {
+		t.Fatalf("openapi = %q, want 3.1.0", document.OpenAPI)
+	}
+	if document.Info["title"] == "" {
+		t.Fatal("info.title is required")
+	}
+
+	expected := map[string][]string{
+		"/api/event":            {"post"},
+		"/api/search":           {"post"},
+		"/contact":              {"get", "post"},
+		"/zh-tw/contact":        {"get", "post"},
+		"/zh-cn/contact":        {"get", "post"},
+		"/healthz":              {"get"},
+		"/admin/leads":          {"get"},
+		"/admin/leads.csv":      {"get"},
+		"/admin/reload-content": {"post"},
+	}
+	for path, methods := range expected {
+		operations, ok := document.Paths[path]
+		if !ok {
+			t.Fatalf("missing path %s", path)
+		}
+		for _, method := range methods {
+			if operations[method] == nil {
+				t.Fatalf("missing %s %s", method, path)
+			}
+		}
+	}
+}


### PR DESCRIPTION
Summary:
- Add docs/openapi.yaml covering the implemented website API, form, health, and admin contracts.
- Add docs/API_REFERENCE.md as the human-readable companion reference.
- Link the API docs from README and SPEC, and add a Go test to verify the OpenAPI document covers runtime endpoints.

Validation:
- go test ./docs
- go test ./...
- git diff --check

Notes:
- This documents rtk_cloud_frontend runtime endpoints only; it intentionally does not describe future IoT product control-plane APIs.