### PR TITLE
[codex] Document persistence cache boundaries

### DIFF
--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -451,6 +451,13 @@ SQLite stores website leads only. It does not store real IoT telemetry or device
 
 When analytics is enabled, first-party event telemetry uses a separate SQLite database so raw analytics data stays isolated from lead data.
 
+Redis-compatible caching is low priority for this repository. Leads, analytics,
+and documentation search should remain concrete SQLite repositories unless a
+specific runtime bottleneck appears. Any future cache work should document the
+need first and must not turn the public website into a product device-state or
+telemetry source of truth. The cross-repository roadmap is maintained in
+`../../docs/persistence-cache-refactor-roadmap.md`.
+
 Default database path:
 
 ```text


### PR DESCRIPTION
## Summary

- Documents that Redis-compatible caching is low priority for website-local SQLite repositories.
- Clarifies that leads, analytics, and documentation search remain local SQLite data unless a concrete bottleneck appears.
- Links the workspace roadmap and the developer issue.

## Validation

- Docs-only change.
- Verified diff is limited to `docs/SPEC.md`.

Related issue: #121
Workspace roadmap: https://github.com/hkt999rtk/rtk_cloud_workspace/blob/codex/persistence-cache-docs/docs/persistence-cache-refactor-roadmap.md
