### PR TITLE
Document SQLite cache boundaries

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,9 @@ The full roadmap and developer issue backlog live in [`docs/SPEC.md`](docs/SPEC.
 The service logging migration to `rtk_cloud_logger` zap and central journald
 forwarding is documented in
 [`docs/SERVICE_LOGGING_MIGRATION.md`](docs/SERVICE_LOGGING_MIGRATION.md).
+Website-local SQLite persistence and the low-priority Redis/cache boundary are
+documented in
+[`docs/PERSISTENCE_CACHE_BOUNDARIES.md`](docs/PERSISTENCE_CACHE_BOUNDARIES.md).
 The implemented website HTTP API is documented in
 [`docs/API_REFERENCE.md`](docs/API_REFERENCE.md), with a machine-readable
 OpenAPI contract in [`docs/openapi.yaml`](docs/openapi.yaml).
@@ -97,6 +100,13 @@ Documentation query:
 - Start the server with `SEARCH_ENABLED=true` only after `SEARCH_DATABASE_PATH` points at a built index and `OPENAI_API_KEY` is configured.
 - Search answers are generated only when retrieved website content clears the relevance threshold. No matching documentation returns a controlled no-hit answer without calling the answer model.
 - Search query text is sent to OpenAI for embeddings. When sources are found, the query and retrieved snippets are sent to the OpenAI Responses API to generate a source-grounded answer. Raw query text is not stored in the analytics event payload.
+
+Persistence and cache boundary:
+
+- Contact leads, first-party analytics, and the local documentation search index remain concrete SQLite repositories unless a measured website bottleneck or concrete operational need justifies different cache work.
+- Do not add Redis or Redis-compatible caching to this repository only because the broader platform may use it.
+- Website SQLite stores must not hold authoritative IoT telemetry, product device state, customer account state, fleet data, OTA execution state, or production mobile app user state.
+- CDN/static cache headers remain separate from application Redis/cache decisions.
 
 CDN readiness:
 

--- a/docs/PERSISTENCE_CACHE_BOUNDARIES.md
+++ b/docs/PERSISTENCE_CACHE_BOUNDARIES.md
@@ -1,0 +1,59 @@
+# Persistence And Cache Boundaries
+
+This repository is a Go-rendered public website and documentation surface. Its
+runtime persistence is intentionally small and website-local. Redis-compatible
+caching is not a first-priority dependency for this repository unless measured
+runtime behavior shows a concrete bottleneck or an operational requirement that
+SQLite and existing HTTP/CDN cache controls cannot satisfy.
+
+## Website-Owned SQLite Stores
+
+The website owns these local SQLite stores:
+
+- `connectplus.db`: contact lead capture for public forms and protected admin
+  lead review.
+- `analytics.db`: first-party website analytics events and aggregate admin
+  reporting.
+- `search.db`: precomputed documentation search documents, chunks, embeddings,
+  and source metadata.
+
+Keep these as concrete SQLite repositories by default. They are small,
+deployment-local data stores that match the current website workload and backup
+model. Future cache work must start from a measured bottleneck, such as observed
+query latency, lock contention, startup cost, operational restore pain, or a
+specific multi-instance deployment requirement.
+
+## Out-Of-Scope State
+
+The website SQLite stores must not become authoritative storage for IoT platform
+state. In particular, do not store these classes of data in this repository's
+website databases:
+
+- real device telemetry
+- product device state
+- customer account state
+- fleet inventory or authoritative fleet control data
+- OTA campaign execution state
+- production mobile app user state
+
+Those domains belong to the platform services and contracts outside this
+marketing/documentation website.
+
+## Cache Boundary
+
+Redis or Redis-compatible cache infrastructure should not be added only because
+the broader platform may use it. For this repository, Redis is low priority
+until there is a documented operational need.
+
+When proposing Redis or another application cache, document:
+
+- the measured website bottleneck or concrete operational requirement
+- why the current SQLite repository, precomputed search index, or static asset
+  strategy is insufficient
+- the intended invalidation and backup behavior
+- how the change preserves public routes, payloads, admin lead behavior,
+  analytics behavior, and documentation search behavior
+
+CDN and static asset cache headers are a separate deployment concern. Keep
+`ENABLE_CDN_CACHE_HEADERS`, asset fingerprints, reverse proxy rules, and CDN
+provider configuration separate from application Redis/cache work.

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -437,6 +437,13 @@ CDN-ready behavior:
   - `/robots.txt` and `/sitemap.xml`: `Cache-Control: public, max-age=300`.
 - The CD workflow intentionally does not enable the CDN env vars yet. CDN provider selection, DNS cutover, cache rules, purge strategy, compression, and TLS settings should be completed as a deployment decision.
 
+Persistence and cache boundaries:
+
+- Contact leads, first-party analytics events, and the precomputed documentation search index are website-local SQLite repositories.
+- Redis-compatible caching is not a first-priority dependency for this repository. Future application cache work must be justified by a measured website bottleneck or concrete operational requirement.
+- Website SQLite stores must not become authoritative storage for real IoT telemetry, product device state, customer account state, fleet inventory or control data, OTA campaign execution state, or production mobile app user state.
+- CDN/static cache headers, asset fingerprints, reverse proxy rules, and CDN provider configuration are deployment concerns separate from application Redis/cache work.
+
 Commands:
 
 - `go run ./cmd/server`


### PR DESCRIPTION
Summary:
- adds a dedicated persistence/cache boundary doc for website-local SQLite stores
- links the Redis low-priority guidance from README and docs/SPEC.md
- clarifies that future cache work needs a measured bottleneck or concrete operational need and keeps CDN/static cache headers separate

Tests:
- go test ./...

Closes #121
