### PR TITLE
[codex] Gate frontend release artifact uploads

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,37 +55,6 @@ jobs:
         id: build
         run: go build ./cmd/server
 
-      - name: Select CI artifact version
-        id: artifact_version
-        shell: bash
-        run: |
-          printf 'version=ci-%s\n' "${GITHUB_SHA::12}" >> "$GITHUB_OUTPUT"
-
-      - name: Build deployable bundle
-        id: package
-        shell: bash
-        env:
-          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
-          SEARCH_EMBEDDING_MODEL: text-embedding-3-small
-        run: |
-          chmod +x deploy/*.sh
-          deploy/package.sh "${{ steps.artifact_version.outputs.version }}"
-          deploy/check-release.sh "dist/realtek-connect-${{ steps.artifact_version.outputs.version }}"
-
-      - name: Upload deployable bundle to Linode Object Storage
-        if: github.event_name == 'workflow_dispatch' || startsWith(github.ref, 'refs/tags/') || github.ref == 'refs/heads/main'
-        shell: bash
-        env:
-          AWS_ACCESS_KEY_ID: ${{ secrets.LINODE_OBJ_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.LINODE_OBJ_SECRET_ACCESS_KEY }}
-          LINODE_TOKEN: ${{ secrets.LINODE_TOKEN }}
-          AWS_DEFAULT_REGION: us-sea
-          AWS_EC2_METADATA_DISABLED: "true"
-          LINODE_OBJ_BUCKET: ${{ vars.LINODE_OBJ_BUCKET }}
-          LINODE_OBJ_ENDPOINT: ${{ vars.LINODE_OBJ_ENDPOINT }}
-        run: |
-          deploy/upload-linode-artifact.sh "${{ steps.artifact_version.outputs.version }}"
-
       - name: Run visual smoke
         id: visual_smoke
         shell: bash

--- a/README.md
+++ b/README.md
@@ -224,9 +224,9 @@ Deployment notes:
 
 Artifact-based Linode deployment is also supported:
 
-- CI builds deployable `realtek-connect-ci-<shortsha>` artifacts for every PR, `main` push, tag, and manual run. On `main`, tags, and manual runs, CI also uploads the bundle, checksum, and manifest to Linode Object Storage under `releases/realtek_connect-ci-<shortsha>/`.
+- CI validates source, tests, server build, and visual smoke evidence. It does not publish deployable release bundles to Linode Object Storage.
 - `deploy/package.sh <version>` creates `dist/realtek-connect-<version>.tar.gz`, a checksum, and an object-storage manifest. When `OPENAI_API_KEY` is present, the bundle includes `data/search.db` as a precomputed documentation search index.
-- `deploy/upload-linode-artifact.sh <version>` uploads the release bundle, checksum, and manifest to Linode Object Storage using the S3-compatible HTTP API directly; it does not require the AWS CLI. It requires either `LINODE_OBJ_ACCESS_KEY_ID` and `LINODE_OBJ_SECRET_ACCESS_KEY`, or `LINODE_TOKEN` so it can create a temporary bucket-scoped Object Storage key. `LINODE_OBJ_BUCKET` and `LINODE_OBJ_ENDPOINT` may be provided explicitly; when only one bucket exists, the script can infer both from the Linode API.
+- `deploy/upload-linode-artifact.sh <version>` validates the release bundle, checksum, manifest version, and source commit before uploading to Linode Object Storage using the S3-compatible HTTP API directly; it does not require the AWS CLI. It requires either `LINODE_OBJ_ACCESS_KEY_ID` and `LINODE_OBJ_SECRET_ACCESS_KEY`, or `LINODE_TOKEN` so it can create a temporary bucket-scoped Object Storage key. `LINODE_OBJ_BUCKET` and `LINODE_OBJ_ENDPOINT` may be provided explicitly; when only one bucket exists, the script can infer both from the Linode API.
 - `.github/workflows/release.yml` publishes release bundles to GitHub Releases and Linode Object Storage under `releases/realtek_connect-<version>/`.
 - `.github/workflows/deploy-linode.yml` installs a selected version onto a standalone Linode VM and verifies public health.
 - Linode VM, GoDaddy DNS, nginx, TLS, rollback, and SQLite backup runbooks live in:

--- a/deploy/package.sh
+++ b/deploy/package.sh
@@ -86,6 +86,7 @@ printf '%s  %s\n' "$bundle_sha" "$(basename "$bundle")" > "$checksum"
 
 python3 - "$object_manifest" "$version" "$source_commit" "$created_at" "$bundle_sha" <<'PY'
 import json
+import os
 import sys
 from pathlib import Path
 
@@ -95,11 +96,16 @@ bundle = f"{version}.tar.gz"
 manifest = {
     "artifact_name": artifact_name,
     "artifact_path": f"releases/{artifact_name}-{version}/{bundle}",
+    "artifact_type": "release-bundle",
     "bundle": bundle,
     "created_at": created_at,
+    "repo": os.environ.get("GITHUB_REPOSITORY", "rtk_cloud_frontend"),
+    "run_attempt": os.environ.get("GITHUB_RUN_ATTEMPT", ""),
+    "run_id": os.environ.get("GITHUB_RUN_ID", ""),
     "sha256": bundle_sha,
     "source_commit": source_commit,
     "version": version,
+    "workflow": os.environ.get("GITHUB_WORKFLOW", ""),
 }
 Path(out).write_text(json.dumps(manifest, indent=2, sort_keys=True) + "\n")
 PY

--- a/deploy/upload-linode-artifact.sh
+++ b/deploy/upload-linode-artifact.sh
@@ -26,6 +26,55 @@ test -f "$bundle"
 test -f "$checksum"
 test -f "$manifest"
 
+(
+  cd "$dist_dir"
+  shasum -a 256 -c "realtek-connect-$version.tar.gz.sha256"
+)
+
+expected_source_commit="${GITHUB_SHA:-$(git -C "$repo_root" rev-parse HEAD 2>/dev/null || echo unknown)}"
+python3 - "$manifest" "$version" "$expected_source_commit" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+manifest_path, expected_version, expected_source_commit = sys.argv[1:]
+manifest = json.loads(Path(manifest_path).read_text(encoding="utf-8"))
+required = {
+    "artifact_name",
+    "artifact_path",
+    "artifact_type",
+    "bundle",
+    "created_at",
+    "repo",
+    "run_attempt",
+    "run_id",
+    "sha256",
+    "source_commit",
+    "version",
+    "workflow",
+}
+missing = sorted(required - set(manifest))
+if missing:
+    raise SystemExit(f"object manifest missing keys: {', '.join(missing)}")
+if manifest["artifact_type"] != "release-bundle":
+    raise SystemExit("object manifest artifact_type must be release-bundle")
+if manifest["version"] != expected_version:
+    raise SystemExit("object manifest version does not match requested upload version")
+if manifest["source_commit"] != expected_source_commit:
+    raise SystemExit(
+        "object manifest source_commit does not match this workflow commit: "
+        f"{manifest['source_commit']} != {expected_source_commit}"
+    )
+expected_path = f"releases/{manifest['artifact_name']}-{expected_version}/{manifest['bundle']}"
+if manifest["artifact_path"] != expected_path:
+    raise SystemExit("object manifest artifact_path does not match release prefix")
+PY
+
+if [[ "${LINODE_UPLOAD_DRY_RUN:-false}" == "true" || "${LINODE_UPLOAD_DRY_RUN:-}" == "1" ]]; then
+  echo "dry-run: validated $bundle, $checksum, and $manifest"
+  exit 0
+fi
+
 linode_api="${LINODE_API_URL:-https://api.linode.com/v4}"
 temp_key_id=""
 bucket_region="${LINODE_OBJ_REGION:-${AWS_DEFAULT_REGION:-us-sea}}"
@@ -158,11 +207,6 @@ test -n "${LINODE_OBJ_BUCKET:-}"
 test -n "${LINODE_OBJ_ENDPOINT:-}"
 test -n "$bucket_region"
 command -v curl >/dev/null 2>&1
-
-(
-  cd "$dist_dir"
-  shasum -a 256 -c "realtek-connect-$version.tar.gz.sha256"
-)
 
 object_checksum_file="$(mktemp)"
 trap 'rm -f "$object_checksum_file"; delete_temp_key' EXIT

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -493,6 +493,7 @@ Linode artifact deployment notes:
 
 - `deploy/package.sh <version>` builds `dist/realtek-connect-<version>.tar.gz`, `realtek-connect-<version>.tar.gz.sha256`, and `realtek-connect-<version>.object-manifest.json`.
 - Release artifacts contain the server binary, `content/`, `templates/`, `static/`, `deploy/`, `VERSION`, and release manifest metadata. SQLite runtime DB files are excluded; the only SQLite DB allowed in a release bundle is optional precomputed `data/search.db`.
+- CI validates source, tests, server build, and visual smoke evidence, but does not upload deployable release bundles to Linode Object Storage.
 - `.github/workflows/release.yml` publishes versioned artifacts to GitHub Releases and Linode Object Storage under `releases/realtek_connect-<version>/`.
 - `.github/workflows/deploy-linode.yml` installs a selected version to `/opt/realtek-connect/releases/<version>`, updates `/opt/realtek-connect/current`, restarts `realtek-connect.service`, and runs public readiness checks.
 - Linode host bootstrap, GoDaddy DNS, nginx reverse proxy, Let’s Encrypt TLS, rollback, and SQLite backup are documented in `docs/deployment-linode.md`, `docs/deployment-promotion-rollback.md`, and `docs/sqlite-backup-linode.md`.

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -451,6 +451,13 @@ SQLite stores website leads only. It does not store real IoT telemetry or device
 
 When analytics is enabled, first-party event telemetry uses a separate SQLite database so raw analytics data stays isolated from lead data.
 
+Redis-compatible caching is low priority for this repository. Leads, analytics,
+and documentation search should remain concrete SQLite repositories unless a
+specific runtime bottleneck appears. Any future cache work should document the
+need first and must not turn the public website into a product device-state or
+telemetry source of truth. The cross-repository roadmap is maintained in
+`../../docs/persistence-cache-refactor-roadmap.md`.
+
 Default database path:
 
 ```text

--- a/docs/deployment-linode.md
+++ b/docs/deployment-linode.md
@@ -8,14 +8,12 @@ replace that test deployment.
 
 Realtek Connect+ uses an artifact-first deployment model:
 
-- CI builds `realtek-connect-ci-<shortsha>.tar.gz` for every PR and push.
-- CI uploads every deployable bundle as a GitHub Actions artifact named
-  `realtek-connect-ci-<shortsha>`.
-- On `main`, tags, and manual runs, CI also uploads the bundle, checksum, and
-  manifest to Linode Object Storage under `releases/realtek_connect-ci-<shortsha>/`.
+- CI validates source, tests, server build, and visual smoke evidence. It does
+  not publish deployable release bundles to Linode Object Storage.
 - The release workflow uploads explicit release bundles to GitHub Releases and
   Linode Object Storage under `releases/realtek_connect-<version>/`.
-- The Linode deploy workflow installs a selected version onto the VM.
+- The Linode deploy workflow downloads, verifies, and installs a selected
+  release version onto the VM. It does not build or publish release artifacts.
 - Rollback deploys a previous published artifact version.
 - Runtime Go service logs should emit `rtk_cloud_logger` zap JSON to
   stdout/stderr for journald collection and central forwarding; see
@@ -33,8 +31,8 @@ Do not deploy production by copying a developer checkout to the VM.
 
 Required secrets:
 
-- `LINODE_TOKEN`, used by CI to create a temporary bucket-scoped Object Storage
-  key for artifact upload.
+- `LINODE_TOKEN`, used by release upload to create a temporary bucket-scoped
+  Object Storage key when long-lived Object Storage credentials are not set.
 - Optional `LINODE_OBJ_ACCESS_KEY_ID` and `LINODE_OBJ_SECRET_ACCESS_KEY` if a
   long-lived bucket-scoped key is preferred over temporary keys.
 - `REALTEK_CONNECT_DEPLOY_HOST`
@@ -58,30 +56,24 @@ Optional variables:
 - `REALTEK_CONNECT_DEPLOY_DATA_DIR`, default `/var/lib/realtek-connect`
 - `REALTEK_CONNECT_DEPLOY_REMOTE_DIR`, default `/tmp/realtek-connect-deploy`
 
-## CI Artifact Contract
+## Release Artifact Contract
 
-Every CI run builds and verifies a deployment-ready bundle:
-
-```text
-realtek-connect-ci-<shortsha>
-realtek-connect-ci-<shortsha>.tar.gz
-realtek-connect-ci-<shortsha>.tar.gz.sha256
-realtek-connect-ci-<shortsha>.object-manifest.json
-```
-
-For `main`, tags, and manual CI runs, the same files are published to Linode
-Object Storage:
+Only the `Release Bundle` workflow publishes deployable release bundles to
+Linode Object Storage:
 
 ```text
-releases/realtek_connect-ci-<shortsha>/ci-<shortsha>.tar.gz
-releases/realtek_connect-ci-<shortsha>/ci-<shortsha>.tar.gz.sha256
-releases/realtek_connect-ci-<shortsha>/manifest.json
+releases/realtek_connect-<version>/<version>.tar.gz
+releases/realtek_connect-<version>/<version>.tar.gz.sha256
+releases/realtek_connect-<version>/manifest.json
 ```
 
-Pull request CI never uploads to Object Storage and does not require Linode
-secrets. The bundle includes the binary, `content/`, `templates/`, `static/`,
-`deploy/`, `VERSION`, and release manifests. Runtime SQLite database files must
-not be included.
+CI does not upload release artifacts and does not require Linode Object Storage
+secrets. The release bundle includes the binary, `content/`, `templates/`,
+`static/`, `deploy/`, `VERSION`, and release manifests. Runtime SQLite database
+files must not be included. The object manifest records
+`artifact_type: release-bundle`, source commit, workflow name, run id, run
+attempt, and checksum. Upload fails if the manifest source commit or version
+does not match the current release workflow run.
 
 The upload script supports two authentication modes. If
 `LINODE_OBJ_ACCESS_KEY_ID` and `LINODE_OBJ_SECRET_ACCESS_KEY` are present, it


### PR DESCRIPTION
## Summary

- Remove deployable release bundle packaging/upload from the frontend CI workflow.
- Keep release bundle publication exclusively in the Release Bundle workflow.
- Add upload-time validation for bundle checksum, manifest version, source commit, release prefix, and artifact type.
- Extend release object manifests with workflow/run provenance.
- Update docs to distinguish CI validation, release bundle upload, and deploy consumption.

## Why

A normal CI run could upload deployable bundles to Linode Object Storage under the release prefix. That made Object Storage artifacts look like evidence that the shared Linode runner or release flow had run, even when the upload came from GitHub-hosted CI. The new flow keeps CI as validation only and requires release upload to pass rebuild/manifest/checksum gates.

## Validation

- Parsed `.github/workflows/ci.yml`, `.github/workflows/release.yml`, and `.github/workflows/deploy-linode.yml` with PyYAML.
- Confirmed CI workflow no longer calls `deploy/upload-linode-artifact.sh`.
- `git diff --check`
- `bash -n deploy/package.sh deploy/upload-linode-artifact.sh deploy/check-release.sh`
- `GOWORK=off go test ./...`
- `GOWORK=off go build ./cmd/server`
- `GOWORK=off BUILD_SEARCH_INDEX=false deploy/package.sh test-version`
- `GOWORK=off deploy/check-release.sh dist/realtek-connect-test-version`
- `GITHUB_SHA=$(git rev-parse HEAD) LINODE_UPLOAD_DRY_RUN=1 deploy/upload-linode-artifact.sh test-version`
- Verified mismatched `GITHUB_SHA` fails upload validation.
