### PR TITLE
[codex] Use Go Object Storage helper

### DIFF
--- a/cmd/linode-object-storage/main.go
+++ b/cmd/linode-object-storage/main.go
@@ -1,0 +1,292 @@
+package main
+
+import (
+	"bytes"
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+)
+
+type objectStore struct {
+	bucket    string
+	endpoint  string
+	accessKey string
+	secretKey string
+	region    string
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		die("usage: linode-object-storage <put|download|cat|exists> [options]")
+	}
+	store, err := storeFromEnv()
+	if err != nil {
+		die(err.Error())
+	}
+	switch os.Args[1] {
+	case "put":
+		fs := flag.NewFlagSet("put", flag.ExitOnError)
+		file := fs.String("file", "", "source file")
+		key := fs.String("key", "", "object key")
+		_ = fs.Parse(os.Args[2:])
+		if *file == "" || *key == "" {
+			die("--file and --key are required")
+		}
+		if err := putObjectFromFile(store, *key, *file); err != nil {
+			die(err.Error())
+		}
+	case "download":
+		fs := flag.NewFlagSet("download", flag.ExitOnError)
+		key := fs.String("key", "", "object key")
+		out := fs.String("out", "", "output path")
+		_ = fs.Parse(os.Args[2:])
+		if *key == "" || *out == "" {
+			die("--key and --out are required")
+		}
+		if err := downloadObject(store, *key, *out); err != nil {
+			die(err.Error())
+		}
+	case "cat":
+		fs := flag.NewFlagSet("cat", flag.ExitOnError)
+		key := fs.String("key", "", "object key")
+		_ = fs.Parse(os.Args[2:])
+		if *key == "" {
+			die("--key is required")
+		}
+		if err := writeObject(store, *key, os.Stdout); err != nil {
+			die(err.Error())
+		}
+	case "exists":
+		fs := flag.NewFlagSet("exists", flag.ExitOnError)
+		key := fs.String("key", "", "object key")
+		_ = fs.Parse(os.Args[2:])
+		if *key == "" {
+			die("--key is required")
+		}
+		if err := objectExists(store, *key); err != nil {
+			die(err.Error())
+		}
+	default:
+		die("unknown command: " + os.Args[1])
+	}
+}
+
+func die(message string) {
+	fmt.Fprintln(os.Stderr, "error: "+message)
+	os.Exit(1)
+}
+
+func storeFromEnv() (objectStore, error) {
+	store := objectStore{
+		bucket:    strings.TrimSpace(os.Getenv("LINODE_OBJ_BUCKET")),
+		endpoint:  strings.TrimRight(strings.TrimSpace(os.Getenv("LINODE_OBJ_ENDPOINT")), "/"),
+		accessKey: firstNonEmpty(os.Getenv("LINODE_OBJ_ACCESS_KEY_ID"), os.Getenv("AWS_ACCESS_KEY_ID")),
+		secretKey: firstNonEmpty(os.Getenv("LINODE_OBJ_SECRET_ACCESS_KEY"), os.Getenv("AWS_SECRET_ACCESS_KEY")),
+		region:    strings.TrimSpace(os.Getenv("LINODE_OBJ_REGION")),
+	}
+	if store.bucket == "" {
+		return store, errors.New("LINODE_OBJ_BUCKET is required")
+	}
+	if store.endpoint == "" {
+		return store, errors.New("LINODE_OBJ_ENDPOINT is required")
+	}
+	if store.accessKey == "" || store.secretKey == "" {
+		return store, errors.New("LINODE_OBJ_ACCESS_KEY_ID and LINODE_OBJ_SECRET_ACCESS_KEY are required")
+	}
+	if store.region == "" {
+		store.region = regionFromEndpoint(store.endpoint)
+	}
+	return store, nil
+}
+
+func putObjectFromFile(store objectStore, key, file string) error {
+	body, err := os.ReadFile(file)
+	if err != nil {
+		return err
+	}
+	_, err = signedObjectRequest(store, http.MethodPut, key, body)
+	return err
+}
+
+func downloadObject(store objectStore, key, out string) error {
+	if err := os.MkdirAll(filepath.Dir(out), 0o755); err != nil {
+		return err
+	}
+	fh, err := os.Create(out)
+	if err != nil {
+		return err
+	}
+	defer fh.Close()
+	return writeObject(store, key, fh)
+}
+
+func writeObject(store objectStore, key string, out io.Writer) error {
+	body, err := signedObjectRequest(store, http.MethodGet, key, nil)
+	if err != nil {
+		return err
+	}
+	_, err = out.Write(body)
+	return err
+}
+
+func objectExists(store objectStore, key string) error {
+	_, err := signedObjectRequest(store, http.MethodHead, key, nil)
+	return err
+}
+
+func signedObjectRequest(store objectStore, method, key string, body []byte) ([]byte, error) {
+	endpointURL, err := url.Parse(store.endpoint)
+	if err != nil {
+		return nil, err
+	}
+	canonicalURI := "/" + store.bucket
+	if key != "" {
+		canonicalURI += "/" + escapeObjectPath(key)
+	}
+	endpointURL.Path = canonicalURI
+	endpointURL.RawQuery = ""
+
+	now := time.Now().UTC()
+	amzDate := now.Format("20060102T150405Z")
+	date := now.Format("20060102")
+	payloadHash := hexSHA256(body)
+	req, err := http.NewRequest(method, endpointURL.String(), bytes.NewReader(body))
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Host", endpointURL.Host)
+	req.Header.Set("X-Amz-Content-Sha256", payloadHash)
+	req.Header.Set("X-Amz-Date", amzDate)
+	if method == http.MethodPut {
+		req.Header.Set("Content-Type", contentType(key))
+	}
+	req.Host = endpointURL.Host
+
+	signedHeaders, canonicalHeaders := canonicalHeaders(req.Header)
+	canonicalRequest := strings.Join([]string{
+		method,
+		canonicalURI,
+		"",
+		canonicalHeaders,
+		signedHeaders,
+		payloadHash,
+	}, "\n")
+	scope := date + "/" + store.region + "/s3/aws4_request"
+	stringToSign := strings.Join([]string{
+		"AWS4-HMAC-SHA256",
+		amzDate,
+		scope,
+		hexSHA256([]byte(canonicalRequest)),
+	}, "\n")
+	signature := hex.EncodeToString(hmacSHA256(signingKey(store.secretKey, date, store.region), []byte(stringToSign)))
+	req.Header.Set("Authorization", "AWS4-HMAC-SHA256 Credential="+store.accessKey+"/"+scope+", SignedHeaders="+signedHeaders+", Signature="+signature)
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	data, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return nil, fmt.Errorf("Object Storage %s %s failed: HTTP %d", method, key, resp.StatusCode)
+	}
+	return data, nil
+}
+
+func canonicalHeaders(headers http.Header) (string, string) {
+	names := make([]string, 0, len(headers))
+	lowerToCanonical := make(map[string]string, len(headers))
+	for name := range headers {
+		lower := strings.ToLower(name)
+		names = append(names, lower)
+		lowerToCanonical[lower] = name
+	}
+	sort.Strings(names)
+	var b strings.Builder
+	for _, name := range names {
+		values := headers.Values(lowerToCanonical[name])
+		for i := range values {
+			values[i] = strings.Join(strings.Fields(values[i]), " ")
+		}
+		b.WriteString(name)
+		b.WriteByte(':')
+		b.WriteString(strings.Join(values, ","))
+		b.WriteByte('\n')
+	}
+	return strings.Join(names, ";"), b.String()
+}
+
+func escapeObjectPath(path string) string {
+	parts := strings.Split(path, "/")
+	for i, part := range parts {
+		parts[i] = url.PathEscape(part)
+	}
+	return strings.Join(parts, "/")
+}
+
+func signingKey(secret, date, region string) []byte {
+	kDate := hmacSHA256([]byte("AWS4"+secret), []byte(date))
+	kRegion := hmacSHA256(kDate, []byte(region))
+	kService := hmacSHA256(kRegion, []byte("s3"))
+	return hmacSHA256(kService, []byte("aws4_request"))
+}
+
+func hmacSHA256(key, data []byte) []byte {
+	mac := hmac.New(sha256.New, key)
+	_, _ = mac.Write(data)
+	return mac.Sum(nil)
+}
+
+func hexSHA256(data []byte) string {
+	sum := sha256.Sum256(data)
+	return hex.EncodeToString(sum[:])
+}
+
+func regionFromEndpoint(endpoint string) string {
+	u, err := url.Parse(endpoint)
+	if err != nil {
+		return "us-east-1"
+	}
+	host := u.Hostname()
+	if strings.HasSuffix(host, ".linodeobjects.com") {
+		parts := strings.Split(host, ".")
+		if len(parts) > 0 && parts[0] != "" {
+			return parts[0]
+		}
+	}
+	return "us-east-1"
+}
+
+func contentType(key string) string {
+	switch {
+	case strings.HasSuffix(key, ".json"):
+		return "application/json"
+	case strings.HasSuffix(key, ".sha256"):
+		return "text/plain"
+	default:
+		return "application/gzip"
+	}
+}
+
+func firstNonEmpty(values ...string) string {
+	for _, value := range values {
+		if strings.TrimSpace(value) != "" {
+			return strings.TrimSpace(value)
+		}
+	}
+	return ""
+}

--- a/cmd/linode-object-storage/main_test.go
+++ b/cmd/linode-object-storage/main_test.go
@@ -1,0 +1,136 @@
+package main
+
+import (
+	"bytes"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestStoreFromEnvPrefersLinodeCredentials(t *testing.T) {
+	t.Setenv("LINODE_OBJ_BUCKET", "release-bucket")
+	t.Setenv("LINODE_OBJ_ENDPOINT", "https://us-sea-1.linodeobjects.com")
+	t.Setenv("LINODE_OBJ_ACCESS_KEY_ID", "linode-access")
+	t.Setenv("LINODE_OBJ_SECRET_ACCESS_KEY", "linode-secret")
+	t.Setenv("AWS_ACCESS_KEY_ID", "aws-access")
+	t.Setenv("AWS_SECRET_ACCESS_KEY", "aws-secret")
+
+	store, err := storeFromEnv()
+	if err != nil {
+		t.Fatalf("storeFromEnv() error = %v", err)
+	}
+	if store.accessKey != "linode-access" {
+		t.Fatalf("accessKey = %q, want linode-access", store.accessKey)
+	}
+	if store.secretKey != "linode-secret" {
+		t.Fatalf("secretKey = %q, want linode-secret", store.secretKey)
+	}
+	if store.region != "us-sea-1" {
+		t.Fatalf("region = %q, want us-sea-1", store.region)
+	}
+}
+
+func TestPutDownloadCatAndExistsUseSignedPathStyleRequests(t *testing.T) {
+	var putBody []byte
+	var seenMethods []string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		seenMethods = append(seenMethods, r.Method+" "+r.URL.EscapedPath())
+		if got := r.Header.Get("Authorization"); !strings.HasPrefix(got, "AWS4-HMAC-SHA256 ") {
+			t.Fatalf("Authorization header = %q", got)
+		}
+		if got := r.Header.Get("X-Amz-Content-Sha256"); got == "" {
+			t.Fatal("missing X-Amz-Content-Sha256 header")
+		}
+		switch r.Method {
+		case http.MethodPut:
+			data, err := io.ReadAll(r.Body)
+			if err != nil {
+				t.Fatalf("read request body: %v", err)
+			}
+			putBody = data
+			w.WriteHeader(http.StatusOK)
+		case http.MethodGet:
+			_, _ = w.Write([]byte("downloaded"))
+		case http.MethodHead:
+			w.WriteHeader(http.StatusOK)
+		default:
+			t.Fatalf("unexpected method %s", r.Method)
+		}
+	}))
+	defer server.Close()
+
+	store := objectStore{
+		bucket:    "bucket-a",
+		endpoint:  server.URL,
+		accessKey: "access",
+		secretKey: "secret",
+		region:    "us-sea",
+	}
+	source := filepath.Join(t.TempDir(), "bundle.tar.gz")
+	if err := os.WriteFile(source, []byte("payload"), 0o600); err != nil {
+		t.Fatalf("write source: %v", err)
+	}
+	if err := putObjectFromFile(store, "releases/app-v1/v1.tar.gz", source); err != nil {
+		t.Fatalf("putObjectFromFile() error = %v", err)
+	}
+	if !bytes.Equal(putBody, []byte("payload")) {
+		t.Fatalf("uploaded body = %q, want payload", string(putBody))
+	}
+	var cat bytes.Buffer
+	if err := writeObject(store, "releases/app-v1/manifest.json", &cat); err != nil {
+		t.Fatalf("writeObject() error = %v", err)
+	}
+	if cat.String() != "downloaded" {
+		t.Fatalf("cat body = %q, want downloaded", cat.String())
+	}
+	out := filepath.Join(t.TempDir(), "manifest.json")
+	if err := downloadObject(store, "releases/app-v1/manifest.json", out); err != nil {
+		t.Fatalf("downloadObject() error = %v", err)
+	}
+	data, err := os.ReadFile(out)
+	if err != nil {
+		t.Fatalf("read download: %v", err)
+	}
+	if string(data) != "downloaded" {
+		t.Fatalf("downloaded body = %q, want downloaded", string(data))
+	}
+	if err := objectExists(store, "releases/app-v1/manifest.json"); err != nil {
+		t.Fatalf("objectExists() error = %v", err)
+	}
+
+	want := []string{
+		"PUT /bucket-a/releases/app-v1/v1.tar.gz",
+		"GET /bucket-a/releases/app-v1/manifest.json",
+		"GET /bucket-a/releases/app-v1/manifest.json",
+		"HEAD /bucket-a/releases/app-v1/manifest.json",
+	}
+	if strings.Join(seenMethods, "\n") != strings.Join(want, "\n") {
+		t.Fatalf("requests = %#v, want %#v", seenMethods, want)
+	}
+}
+
+func TestObjectExistsReportsServerError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusForbidden)
+	}))
+	defer server.Close()
+
+	store := objectStore{
+		bucket:    "bucket-a",
+		endpoint:  server.URL,
+		accessKey: "access",
+		secretKey: "secret",
+		region:    "us-sea",
+	}
+	err := objectExists(store, "blocked")
+	if err == nil {
+		t.Fatal("objectExists() error = nil, want HTTP error")
+	}
+	if !strings.Contains(err.Error(), "HTTP 403") {
+		t.Fatalf("error = %q, want HTTP 403", err.Error())
+	}
+}

--- a/deploy/upload-linode-artifact.sh
+++ b/deploy/upload-linode-artifact.sh
@@ -217,88 +217,12 @@ bundle_sha="$(shasum -a 256 "$bundle" | awk '{print $1}')"
 printf '%s  %s\n' "$bundle_sha" "$object_bundle" >"$object_checksum_file"
 
 prefix="s3://$LINODE_OBJ_BUCKET/releases/$artifact_name-$version"
+export LINODE_OBJ_REGION="$bucket_region"
 
 s3_put() {
   local file="$1"
   local key="$2"
-  local endpoint_no_scheme="${LINODE_OBJ_ENDPOINT#https://}"
-  endpoint_no_scheme="${endpoint_no_scheme#http://}"
-  endpoint_no_scheme="${endpoint_no_scheme%%/}"
-  endpoint_no_scheme="${endpoint_no_scheme#${LINODE_OBJ_BUCKET}.}"
-  local scheme="https"
-  if [[ "$LINODE_OBJ_ENDPOINT" == http://* ]]; then
-    scheme="http"
-  fi
-  local host="$LINODE_OBJ_BUCKET.$endpoint_no_scheme"
-  local url="$scheme://$host/$key"
-  local encoded_key
-  encoded_key="$(python3 - "$key" <<'PY'
-import sys
-from urllib.parse import quote
-print("/".join(quote(part, safe="") for part in sys.argv[1].split("/")))
-PY
-)"
-  local signed_headers
-  signed_headers="$(python3 - "$file" "$host" "/$encoded_key" "$bucket_region" <<'PY'
-import datetime
-import hashlib
-import hmac
-import os
-import sys
-
-path, host, canonical_uri, region = sys.argv[1:]
-access_key = os.environ["AWS_ACCESS_KEY_ID"]
-secret_key = os.environ["AWS_SECRET_ACCESS_KEY"]
-service = "s3"
-payload_hash = hashlib.sha256(open(path, "rb").read()).hexdigest()
-now = datetime.datetime.now(datetime.timezone.utc)
-amz_date = now.strftime("%Y%m%dT%H%M%SZ")
-date_stamp = now.strftime("%Y%m%d")
-canonical_headers = (
-    f"host:{host}\n"
-    f"x-amz-content-sha256:{payload_hash}\n"
-    f"x-amz-date:{amz_date}\n"
-)
-signed_headers = "host;x-amz-content-sha256;x-amz-date"
-canonical_request = "\n".join([
-    "PUT",
-    canonical_uri,
-    "",
-    canonical_headers,
-    signed_headers,
-    payload_hash,
-])
-credential_scope = f"{date_stamp}/{region}/{service}/aws4_request"
-string_to_sign = "\n".join([
-    "AWS4-HMAC-SHA256",
-    amz_date,
-    credential_scope,
-    hashlib.sha256(canonical_request.encode()).hexdigest(),
-])
-def sign(key, msg):
-    return hmac.new(key, msg.encode(), hashlib.sha256).digest()
-signing_key = sign(sign(sign(sign(("AWS4" + secret_key).encode(), date_stamp), region), service), "aws4_request")
-signature = hmac.new(signing_key, string_to_sign.encode(), hashlib.sha256).hexdigest()
-authorization = (
-    f"AWS4-HMAC-SHA256 Credential={access_key}/{credential_scope}, "
-    f"SignedHeaders={signed_headers}, Signature={signature}"
-)
-print(f"x-amz-date:{amz_date}")
-print(f"x-amz-content-sha256:{payload_hash}")
-print(f"authorization:{authorization}")
-PY
-)"
-  local amz_date payload_hash authorization
-  amz_date="$(awk -F: '$1 == "x-amz-date" {print substr($0, index($0, ":") + 1)}' <<<"$signed_headers")"
-  payload_hash="$(awk -F: '$1 == "x-amz-content-sha256" {print substr($0, index($0, ":") + 1)}' <<<"$signed_headers")"
-  authorization="$(awk -F: '$1 == "authorization" {print substr($0, index($0, ":") + 1)}' <<<"$signed_headers")"
-  curl -fsS -X PUT \
-    -H "Host: $host" \
-    -H "x-amz-date: $amz_date" \
-    -H "x-amz-content-sha256: $payload_hash" \
-    -H "Authorization: $authorization" \
-    --upload-file "$file" \
-    "$url" >/dev/null
+  go run ./cmd/linode-object-storage put --file "$file" --key "$key"
 }
 
 s3_put "$bundle" "releases/$artifact_name-$version/$object_bundle"

--- a/docs/sqlite-backup-linode.md
+++ b/docs/sqlite-backup-linode.md
@@ -64,9 +64,9 @@ prefix such as `sqlite-backups/<hostname>/`. Do not use the public release
 artifact prefix for database backups.
 
 ```sh
-aws s3 cp "/var/lib/realtek-connect/backups/connectplus-$ts.db" \
-  "s3://$LINODE_OBJ_BUCKET/sqlite-backups/$(hostname)/connectplus-$ts.db" \
-  --endpoint-url "$LINODE_OBJ_ENDPOINT"
+go run ./cmd/linode-object-storage put \
+  --file "/var/lib/realtek-connect/backups/connectplus-$ts.db" \
+  --key "sqlite-backups/$(hostname)/connectplus-$ts.db"
 ```
 
 ## Restore Procedure


### PR DESCRIPTION
## Summary
- add a repo-local Go Linode Object Storage helper
- replace the legacy inline Python SigV4 uploader in `deploy/upload-linode-artifact.sh` with the Go helper
- update the SQLite backup Object Storage example to use the Go helper

## Validation
- `GOWORK=off go test ./cmd/linode-object-storage ./cmd/server ./cmd/search-index ./cmd/visual-smoke`
- `bash -n deploy/upload-linode-artifact.sh`
- `git diff --check`
